### PR TITLE
Removed extra accent character from local-no-docker.md

### DIFF
--- a/docfx_project/ziti/quickstarts/network/local-no-docker.md
+++ b/docfx_project/ziti/quickstarts/network/local-no-docker.md
@@ -85,7 +85,7 @@ Saving identity 'default' to ${HOME}/.ziti/quickstart/My-Mac-mini.local.domain/z
 Congratulations! You can now use the `ziti` CLI to interact with Ziti! ([Ziti CLI Help Here](~/ziti/cli/cli.md)) The 
 `ziti` binary is not added to your path by default but will be available at `"${ZITI_BIN_DIR-}/ziti"`. Add that folder
 to your path, alias `ziti` if you like. Let's try to use this command to see if the edge router is online by running:
-``"${ZITI_BIN_DIR-}/ziti" edge list edge-routers`.
+`"${ZITI_BIN_DIR-}/ziti" edge list edge-routers`.
 
 ```bash
 ~ % "${ZITI_BIN_DIR-}/ziti" edge list edge-routers


### PR DESCRIPTION
Fixes open [issue 95](https://github.com/openziti/ziti-doc/issues/95)