### PR TITLE
set Docusaurus baseUrl to root; resolves #200

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
   title: 'OpenZiti',
   tagline: 'OpenZiti Tagline',
   url: 'https://openziti.io',
-  baseUrl: '/docusaurus/',
+  baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   favicon: 'img/favicon.ico',

--- a/publish.sh
+++ b/publish.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
-set -e
+set -eu
 
 mkdir -p ~/.ssh
 
 echo running ssh-keyscan to add github.com to known hosts
 mkdir -p ~/.ssh
 ssh-keyscan github.com >> ~/.ssh/known_hosts
-chmod -R 600 ~/.ssh
-chmod -R 600 ~/.ssh/*
+chmod -R u=rwX,go-rwx ~/.ssh/
 
 pub_script_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "publish script located in: $pub_script_root"
@@ -18,19 +17,17 @@ curl -s https://api.github.com/repos/netfoundry/ziti-ci/releases/latest \
   | grep browser_download_url \
   | cut -d ":" -f2,3 \
   | tr -d \" \
-  | wget -q -i - -O ziti-ci
-chmod +x ziti-ci
-mv ziti-ci /usr/bin
+  | wget -q -i - -O ./ziti-ci
+chmod +x ./ziti-ci
+mv ./ziti-ci /usr/bin/
 
-if [ "${GIT_BRANCH}" == "main" ]
-then
+if [ "${GIT_BRANCH:-}" == "main" ]; then
   echo on main branch - publish can proceed
 
-  ./gendoc.sh
-  ./gendoc.sh -dc
+  ./gendoc.sh -d  # clone and build companion microsites and build Docusaurus
 
   echo "configuring git..."
-  ziti-ci configure-git
+  ziti-ci configure-git  # writes key from env var $gh_ci_key to file ./github_deploy_key
   #git add docs docfx_project/ziti-*
 
   #move back to main once we're this deep into the run
@@ -39,23 +36,20 @@ then
     ./changeToSsh.sh
   fi
   git checkout main
-# branch protection disallows this  git diff-index --quiet HEAD || git commit -m "[ci skip] publish docs from travis" && git push
+  # branch protection disallows this  git diff-index --quiet HEAD || git commit -m "[ci skip] publish docs from travis" && git push
 
   echo "cloning actual github pages now to push docs into"
   git clone https://github.com/openziti/openziti.github.io.git
-#  git clone git@github.com:openziti/openziti.github.io.git
+  #  git clone git@github.com:openziti/openziti.github.io.git
 
-  # clean the old site to remove any pages/etc that are no longer around
-  rm -r openziti.github.io/*
+  # recursively clean all visible files (ignore hidden files like .git/)
+  rm -rf ./openziti.github.io/*
 
-  # copy all the docs-local into the publish site
-  cp -r docs-local/* openziti.github.io/
-  mv docusaurus/build openziti.github.io/docusaurus
-  cp -r docusaurus/static/api/* openziti.github.io/docusaurus/
+  # copy Docusaurus build output dir to the publish site dir
+  cp -rT ./docusaurus/build/ ./openziti.github.io/
 
-  cd openziti.github.io
+  cd ./openziti.github.io/
   git add -A
-  git add "$(pwd)/docusaurus/api"
   if [[ "$(git config --get remote.origin.url | cut -b1-3)" == "htt" ]]; then
     echo changing git repo from https to git so that we can push...
     ../changeToSsh.sh
@@ -63,7 +57,7 @@ then
 
   GH_KEY="${pub_script_root}/github_deploy_key"
   if test -f "${GH_KEY}"; then
-    echo "git push should succeed: ${pub_script_root}/github_deploy_key exists..."
+    echo "git push should succeed: ${GH_KEY} exists..."
   else
     echo "${GH_KEY} DID NOT exist???"
   fi
@@ -71,17 +65,22 @@ then
   # copy the known hosts to root... since this is running in a container it's running as the root user
   # and the git commit command is looking for known_hosts at /root/.ssh/known_hosts - although ~/.ssh
   # is at /github/home instead - go figure... /root/.ssh might not exist either so make it just in case
-  mkdir -p /root/.ssh
-  cp $HOME/.ssh/known_hosts /root/.ssh/known_hosts
+  if [[ ${EUID} -eq 0 ]]; then
+    mkdir -p /root/.ssh
+    cp $HOME/.ssh/known_hosts /root/.ssh/known_hosts
+    chown -R root:root /root/.ssh/
+    chmod -R u=rwX,go-rwx /root/.ssh/
+  fi
 
   echo __________________________________________________________________________
   git status
   git config user.name ziti-ci
   git config user.email ziti-ci@netfoundry.io
-  git config core.sshCommand "ssh -i ${pub_script_root}/github_deploy_key"
+  git config core.sshCommand "ssh -i ${GH_KEY}"
 
   echo "showing the git config"
   git config --get remote.origin.url
+  # push unless there are no differences
   git diff-index --quiet HEAD || git commit -m "[ci skip] publish docs from CI" && git push
 
   echo __________________________________________________________________________


### PR DESCRIPTION
~~After this merges you'll need to change the GH pages settings in https://github.com/openziti/openziti.github.io to publish from folder `/docusaurus` instead of `/`.~~

EDIT: GitHub pages can not serve from an arbitrary folder, only from `/` or `/docs`. I'll push more changes to this branch and then mark the PR ready for review.