### PR TITLE
limit failed runs of mattermost webhook and vercel bot noise

### DIFF
--- a/.github/workflows/zitified-web-hook.yml
+++ b/.github/workflows/zitified-web-hook.yml
@@ -18,11 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     name: POST Webhook
     steps:
+      - name: debug
+        run:   echo "$GITHUB_CONTEXT"
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
       - uses: openziti/ziti-mattermost-action-py@main
         if: |
-          github.repository_owner == 'openziti'
-          && ((github.event_name != 'pull_request_review')
-          || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved'))
+          env.ZHOOK_URL != null
+          && !(github.event_name == 'issue_comment' && github.event.sender.login == 'vercel[bot]' && contains(github.event.comment.body, 'Building'))
+          && !(github.event_name == 'pull_request_review' && github.event.review.state != 'approved')
+        env:
+          ZHOOK_URL: ${{ secrets.ZHOOK_URL }}
         with:
           zitiId: ${{ secrets.ZITI_MATTERMOST_IDENTITY }}
           webhookUrl: ${{ secrets.ZHOOK_URL }}


### PR DESCRIPTION
only send to dev-notifications if ZHOOK_URL is defined (excludes forks) and if the message is not a "building" issue comment from vercel[bot]