### PR TITLE
add config file for local/offline pre-commit hook mgmt tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,4 @@
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.32.2
+  hooks:
+  - id: markdownlint


### PR DESCRIPTION

This calls `markdownlint` if the user
* has previously install `pre-commit`
* has previously run `pre-commit install` in this repo

