### PR TITLE
skip docs links to Apple app store (iOS and MacOS) 

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -20,7 +20,6 @@ jobs:
             --exclude=https://(EXWPKK5PV4-dsn.algolia.net|www.googletagmanager.com|mermaid-js.github.io|mermaid.live|github.com/openziti/ziti-doc/blob/main/docusaurus/|play.google.com/store/apps/details\?id=io\.netfoundry\.ziti\.tunnel|apps.apple.com/app/|github.com/openziti/ziti-doc/tree/main/docusaurus/)|#docusaurus_skipToContent_fallback$
             --buffer-size=8192 
             --max-connections=10
-            --rate-limit=10
             --header=User-Agent:curl/7.54.0
             --timeout=20
           debug: true

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,7 +17,7 @@ jobs:
           url: https://openziti.github.io/
           cmd_params: >
             --color=always 
-            --exclude=https://(EXWPKK5PV4-dsn.algolia.net|www.googletagmanager.com|mermaid-js.github.io|mermaid.live|github.com/openziti/ziti-doc/blob/main/docusaurus/|play.google.com/store/apps/details\?id=io\.netfoundry\.ziti\.tunnel|github.com/openziti/ziti-doc/tree/main/docusaurus/)|#docusaurus_skipToContent_fallback$
+            --exclude=https://(EXWPKK5PV4-dsn.algolia.net|www.googletagmanager.com|mermaid-js.github.io|mermaid.live|github.com/openziti/ziti-doc/blob/main/docusaurus/|play.google.com/store/apps/details\?id=io\.netfoundry\.ziti\.tunnel|apps.apple.com/app/|github.com/openziti/ziti-doc/tree/main/docusaurus/)|#docusaurus_skipToContent_fallback$
             --buffer-size=8192 
             --max-connections=10
             --rate-limit=10

--- a/check-broken-links.sh
+++ b/check-broken-links.sh
@@ -13,11 +13,11 @@ fi
 case "$SERVER" in
     https://openziti.github.io*)
         # ignore links that are known to be irrelevant or known issues
-        EXCLUDE='https://(EXWPKK5PV4-dsn.algolia.net|www.googletagmanager.com|mermaid-js.github.io|mermaid.live|play.google.com/store/apps/details\?id=io\.netfoundry\.ziti\.tunnel)|#docusaurus_skipToContent_fallback$' \
+        EXCLUDE='https://(EXWPKK5PV4-dsn.algolia.net|www.googletagmanager.com|mermaid-js.github.io|mermaid.live|play.google.com/store/apps/details\?id=io\.netfoundry\.ziti\.tunnel|apps.apple.com/app/)|#docusaurus_skipToContent_fallback$' \
     ;;
     *)
         # additionally ignore GitHub links if not testing GH Pages site
-        EXCLUDE='https://(EXWPKK5PV4-dsn.algolia.net|www.googletagmanager.com|mermaid-js.github.io|mermaid.live|github.com/openziti/ziti-doc/blob/main/docusaurus/|play.google.com/store/apps/details\?id=io\.netfoundry\.ziti\.tunnel|openziti.github.io|github.com/openziti/ziti-doc/tree/main/docusaurus/)|#docusaurus_skipToContent_fallback$' \
+        EXCLUDE='https://(EXWPKK5PV4-dsn.algolia.net|www.googletagmanager.com|mermaid-js.github.io|mermaid.live|github.com/openziti/ziti-doc/blob/main/docusaurus/|play.google.com/store/apps/details\?id=io\.netfoundry\.ziti\.tunnel|apps.apple.com/app/|openziti.github.io|github.com/openziti/ziti-doc/tree/main/docusaurus/)|#docusaurus_skipToContent_fallback$' \
     ;;
 esac
 


### PR DESCRIPTION
avoid HTTP 429 rate limit errors