### PR TITLE
Miniziti tweaks

### DIFF
--- a/docusaurus/docs/learn/quickstarts/network/local-kubernetes.md
+++ b/docusaurus/docs/learn/quickstarts/network/local-kubernetes.md
@@ -166,11 +166,11 @@ sudo tee -a /etc/hosts <<< "$(minikube --profile miniziti ip) minicontroller.zit
 </Tabs>
 
 <Tabs>
-  <TabItem value="miniziti.bash" label="BASH Script" default>
+  <TabItem value="miniziti.bash" label="miniziti script" default>
 
-## BASH Script
+## miniziti Script
 
-You can run this script or perform the steps manually yourself. Click the "Manual Steps" tab directly above to switch your view. 
+You can run the miniziti shell script or perform the steps manually yourself. Click the "Manual Steps" tab directly above to switch your view. 
 
 It's recommended that you read the script before you run it. It's safe to re-run the script if it encounters a temporary problem.
 
@@ -180,8 +180,8 @@ To run the script you'll need to [download the file](./miniziti.bash) and run it
 bash ./miniziti.bash
 ```
 
-  </TabItem>
-  <TabItem value="manual" label="Manual Steps" default>
+</TabItem>
+<TabItem value="manual" label="Manual Steps" default>
 
 ## Manual Steps to Learn by Doing
 
@@ -527,7 +527,7 @@ helm install "testapi-host" openziti/httpbin \
    --set zitiServiceName=testapi-service
 ```
 
-  </TabItem>
+</TabItem>
 </Tabs>
 
 ## Add the Client Identity

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -61,7 +61,7 @@ function deleteMiniziti(){
 
 function main(){
     # require commands
-    declare -a BINS=(jq ziti minikube kubectl helm)
+    declare -a BINS=(ziti minikube kubectl helm)
     for BIN in "${BINS[@]}"; do
         if ! command -v "$BIN" &>/dev/null; then
             echo "ERROR: this script requires commands '${BINS[*]}'. Please install on the search PATH and try again." >&2


### PR DESCRIPTION
* stop requiring jq because it's not used by miniziti
* manage JWT and JSON files for testapi-host identity to avoid re-run problems with old files
* skip cluster DNS setup if cluster DNS is already working to shave some seconds of waiting
* probe for minikube tunnel _after_ installing controller so there's an ingress to cause it to prompt for sudo password immediately
* detect OS so we can print more appropriate messages, including the Windows path of the client JWT