### PR TITLE
Redirect to full paths

### DIFF
--- a/docusaurus/docs/reference/developer/sdk/ziti-sdk-c.mdx
+++ b/docusaurus/docs/reference/developer/sdk/ziti-sdk-c.mdx
@@ -4,5 +4,5 @@ hide_title: true
 ------
 
 <head>
-    <meta http-equiv="refresh" content="0; URL=./clang/" />
+    <meta http-equiv="refresh" content="0; URL=/docs/reference/developer/sdk/clang/" />
 </head>

--- a/docusaurus/docs/reference/developer/sdk/ziti-sdk-swift.mdx
+++ b/docusaurus/docs/reference/developer/sdk/ziti-sdk-swift.mdx
@@ -4,5 +4,5 @@ hide_title: true
 ------
 
 <head>
-    <meta http-equiv="refresh" content="0; URL=./swift/" />
+    <meta http-equiv="refresh" content="0; URL=/docs/reference/developer/sdk/swift/" />
 </head>


### PR DESCRIPTION
Tested in GH Pages: http://qrkourier.github.io/docs/reference/developer/sdk/ to make sure this solves the problem a user reported with opening the nested SDK doc sites in a new tab or window. In GH Pages the relative link would get interpreted after GH Pages added a trailing slash and so the relative link was one level deeper than it should be.