### PR TITLE
un-orphan link fragments

### DIFF
--- a/docusaurus/docs/learn/core-concepts/security/authentication/20-api-session-certificates.md
+++ b/docusaurus/docs/learn/core-concepts/security/authentication/20-api-session-certificates.md
@@ -1,7 +1,7 @@
 # API Session Certificates
 
 API Session Certificates are ephemeral short-lived x509 certificates that can be created through a CSR process after
-an API Session is [fully authenticated](./auth#full-vs-partial-authentication). 
+an API Session is [fully authenticated](./auth.md#full-vs-partial-authentication). 
 
 ## Lifecycle & Scope
 

--- a/docusaurus/docs/learn/core-concepts/security/authentication/40-certificate-management.md
+++ b/docusaurus/docs/learn/core-concepts/security/authentication/40-certificate-management.md
@@ -19,7 +19,7 @@ have expired, the router must be [re-enrolled](../enrollment#router-enrollment-e
 Clients may determine their own client certificate extension frequency. In order to extend their current client 
 certificate issued by the Ziti PKI, they must issue the following REST request to either the 
 [Edge Management API](/docs/reference/developer/api#edge-management-api) or [Edge Client API](/docs/reference/developer/api#edge-client-api) 
-after becoming [fully authenticated](./auth#full-vs-partial-authentication).
+after becoming [fully authenticated](./auth.md#full-vs-partial-authentication).
 
 ### Client Certificate Extension
 

--- a/docusaurus/docs/learn/core-concepts/security/overview.md
+++ b/docusaurus/docs/learn/core-concepts/security/overview.md
@@ -23,7 +23,7 @@ are related to identity authentication and service access:
 - [Posture Queries](./authorization/posture-checks#posture-data) - describes a request for environmental information from a client
 - [Posture Responses](./authorization/posture-checks#posture-data) - a response to a Posture Query provided by a client
 - [Posture Data](./authorization/posture-checks#posture-data) - the current environmental state provided via Posture Responses and known information
-- [Authentication Queries](./authentication/auth#authentication-queries) - additional, secondary, authentication factors required after initial, primary, authentication
+- [Authentication Queries](./authentication/auth.md#authentication-queries) - additional, secondary, authentication factors required after initial, primary, authentication
 
 There is an additional policy type for Edge Routers:
 

--- a/docusaurus/docs/reference/developer/api/index.md
+++ b/docusaurus/docs/reference/developer/api/index.md
@@ -55,8 +55,8 @@ new identities, identities, policies, and other entities used to manage an OpenZ
 The Edge Client API is used by clients that wish to dial (connect) or bind (host) services. The services that the
 clients are allowed to interact with is defined by [policies](/docs/learn/core-concepts/security/authorization/policies/overview). In order
 for clients to use the client API they must first [authenticate](/docs/learn/core-concepts/security/authentication/auth) and
-obtain either a [partial or fully authenticated](/docs/learn/core-concepts/security/authentication/auth#full-vs-partial-authentication)
-[API Session](/docs/learn/core-concepts/security/sessions#).
+obtain either a [partial or fully authenticated](../../../learn/core-concepts/security/authentication/auth.md#full-vs-partial-authentication)
+[API Session](/docs/learn/core-concepts/security/sessions).
 
 [Explore the latest Edge Client API Reference](./01-edge-client-reference.mdx)
 


### PR DESCRIPTION
the broken link crawler found some orphaned fragments in the Vercel preview of the update.end.to.end.encryption branch, and these changes un-orphaned them in the local dev preview server. Hoping for the same in this branch's Vercel build. :crossed_fingers: 