### PR TITLE
stop crawling links to Ziti's Twitter accounts

### DIFF
--- a/check-links/crawl-for-broken-links.sh
+++ b/check-links/crawl-for-broken-links.sh
@@ -30,6 +30,7 @@ www\.reddit\.com/r/openziti
 .*\.ziti
 .*\.zitik8s
 .*\.svc
+twitter\.com/(OpenZiggy|OpenZiti)
 EOF
 # github\.com/.*/releases/latest/download
 


### PR DESCRIPTION
Twitter's web servers changed the way they handle bot requests. Now they always redirect to a relative URL that exceeds our crawler's default tolerance for redirects. A simple solution is to stop crawling those predictable links. If a class of problems emerges later, we should consider changing redirect tolerances.