### PR TITLE
stop crawling non-HTTPS web links 

### DIFF
--- a/check-links/crawl-for-broken-links.sh
+++ b/check-links/crawl-for-broken-links.sh
@@ -13,7 +13,8 @@ else
     shift
 fi
 
-EXCLUDE_PATTERN="https?://("
+# ignore all http:// links and selected https:// links
+EXCLUDE_PATTERN="(http://|https://("
 while read -r; do
     EXCLUDE_PATTERN+="${REPLY}|"
 done<<EOF
@@ -34,7 +35,7 @@ twitter\.com/(OpenZiggy|OpenZiti)
 EOF
 # github\.com/.*/releases/latest/download
 
-EXCLUDE_PATTERN="${EXCLUDE_PATTERN%|})"
+EXCLUDE_PATTERN="${EXCLUDE_PATTERN%|}))"
 
 docker run --rm --network=host raviqqe/muffet "${SERVER}" \
     --buffer-size=8192 \


### PR DESCRIPTION
because they're always examples, not checkable links

resolves #507 