### PR TITLE
remove browzer sdk

### DIFF
--- a/docusaurus/docs/reference/developer/sdk/index.mdx
+++ b/docusaurus/docs/reference/developer/sdk/index.mdx
@@ -29,7 +29,6 @@ Pick your favorite language and start with a tutorial or sample application. You
         * [Reference](https://github.com/openziti/ziti-sdk-android#readme)
 * [Javascript SDK](https://github.com/openziti/ziti-sdk-js#readme)
     * [Node.js SDK](https://github.com/openziti/ziti-sdk-nodejs)
-    * [browZer SDK](https://github.com/openziti/ziti-sdk-browzer#readme)
 * C# SDK
     * [Repo](https://github.com/openziti/ziti-sdk-csharp#readme)
     * [Reference](./ziti-sdk-csharp.mdx)


### PR DESCRIPTION
links to a repo that is incomplete and best of my info there is no 'sdk' for browzer