### PR TITLE
use long options to correlate with descriptions in doc

### DIFF
--- a/docusaurus/docs/learn/core-concepts/security/authentication/10-third-party-cas.md
+++ b/docusaurus/docs/learn/core-concepts/security/authentication/10-third-party-cas.md
@@ -125,11 +125,19 @@ The fields under `externalIdClaims` is as follows:
 #### Ziti CLI
 
 ```
-ziti edge create ca myCa ca.pem -l SAN_URI -m SCHEME -x spiffe -p "NONE"
+ziti edge create ca myCa ca.pem \
+    --location SAN_URI \
+    --matcher SCHEME \
+    --matcher-criteria spiffe \
+    --parser "NONE"
 ```
 
 ```
-ziti edge update ca myCa -l SAN_URI -m SCHEME -x spiffe -p "NONE"
+ziti edge update ca myCa \
+    --location SAN_URI \
+    --matcher SCHEME \
+    --matcher-criteria spiffe \
+    --parser "NONE"
 ```
 
 ### Location, Matcher, Parser


### PR DESCRIPTION
clarify shell samples with long options that match the descriptions in docs