### PR TITLE
move quickstarts index page to quickstarts category

### DIFF
--- a/docusaurus/docs/learn/quickstarts/_category_.json
+++ b/docusaurus/docs/learn/quickstarts/_category_.json
@@ -1,5 +1,4 @@
 {
   "label": "Quickstarts",
-  "position": 3,
-  "link": { "type": "doc", "id": "learn/quickstarts/network/quickstartOverview" }
+  "position": 3
 }

--- a/docusaurus/docs/learn/quickstarts/network/_category_.json
+++ b/docusaurus/docs/learn/quickstarts/network/_category_.json
@@ -1,4 +1,7 @@
 {
   "label": "Network",
-  "position": 0
+  "position": 0,
+  "link": {
+    "type": "generated-index"
+  }
 }

--- a/docusaurus/docs/learn/quickstarts/quickstarts.md
+++ b/docusaurus/docs/learn/quickstarts/quickstarts.md
@@ -10,7 +10,7 @@ get your own zero trust overlay network setup.
 OpenZiti is bringing Zero Trust to networks all over the world! To really get the most out of Ziti, you'll want to embed
 it **directly** into your applications. Ziti provides numerous SDKs for this very purpose. If you're not ready to embed
 Zero Trust right into your application you can still get started by using one or more of the
-[tunneling apps](/docs/learn/core-concepts/clients/choose).
+[tunneling apps](../core-concepts/clients/choose.mdx).
 
 :::note
 If you get stuck on anything at all, remember that the link to the discourse sites is on the top right of all the doc
@@ -20,7 +20,7 @@ pages. Don't be afraid to ask the community for help!
 ## Getting Started - Network
 
 When you're just getting started, the first thing you will need is access to a
-[Ziti Network](../../introduction/index.mdx). For someone just starting out, there are four basic options:
+[Ziti Network](../introduction/index.mdx). For someone just starting out, there are four basic options:
 
 ### Run all the binaries locally
 
@@ -34,14 +34,14 @@ This allows you to do some more complex things like actually isolate services fr
 ### Run on your own server
 
 This option is great for two situations. If you have a server This is great if you have other people you want to have
-access to your [Ziti Network](../../introduction/index.mdx) and aren't on the local network.
+access to your [Ziti Network](../introduction/index.mdx) and aren't on the local network.
 
-* If you would prefer not to deal with setting up the [Ziti Network](../../introduction/index.mdx) you
+* If you would prefer not to deal with setting up the [Ziti Network](../introduction/index.mdx) you
 * can sign up for a free-tier account over at the [NetFoundry Console](https://nfconsole.io/signup)
 
 ## Which network option sounds right for you?
 
-* [Run Everything Locally - no Docker](./local-no-docker.md)
-* [Run Everything Locally - using Docker](./local-with-docker.md)
-* [Run Everything Locally - Docker Compose](./local-docker-compose.md)
-* [Run Everything Hosted](./hosted.md)
+* [Run Everything Locally - no Docker](./network/local-no-docker.md)
+* [Run Everything Locally - using Docker](./network/local-with-docker.md)
+* [Run Everything Locally - Docker Compose](./network/local-docker-compose.md)
+* [Run Everything Hosted](./network/hosted.md)

--- a/docusaurus/docs/learn/quickstarts/services/ztha.md
+++ b/docusaurus/docs/learn/quickstarts/services/ztha.md
@@ -39,7 +39,7 @@ With an understanding of what we are looking to accomplish in this guide, let's 
 
 ### Prerequisite - OpenZiti Network
 You will need an OpenZiti overlay network in place before you can complete this guide. If you do not have an
-OpenZiti overlay network provisioned yet, [follow a quickstart](../network/index.md) and get a network up and running.
+OpenZiti overlay network provisioned yet, [follow a quickstart](../quickstarts.md) and get a network up and running.
 
 ### Prerequisite - HTTP Server
 You'll need an HTTP server which you plan to connect your HTTP client to. There are numerous ways to 
@@ -71,6 +71,7 @@ Also, the .env file the quickstart emits can be used to put this folder on your 
 followed either the [Local - No Docker](../network/local-no-docker.md) or 
 [Host Ziti Anywhere](../network/hosted.md) quickstart, you should have a file that can be sourced. Here is an example of 
 my personal "Local - No Docker" result when sourcing that file:
+
 ```shell
 $ source ~/.ziti/quickstart/$(hostname -s)/$(hostname -s).env
 
@@ -132,7 +133,6 @@ name of the container running the HTTP server.
 Note that step 7 below requires you to have set the variable named `http_server_id`. All of the quickstarts provision an edge-router 
 with the tunneler option (`-t`) enabled. This means that edge-router is configured to serve as a tunneller. Run `ziti edge list 
 identities` to find the name of the identity associated to the router.
-
 
 ```shell
 # login to your controller - replace the host/port with the correct value

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -156,8 +156,8 @@ const config = {
             from: ['/docs', '/docs/learn', '/docs/introduction/intro', '/docusaurus/docs/overview', '/ziti/overview/', '/ziti/overview.html'],
           },
           {
-            to: '/docs/learn/quickstarts/network/',
-            from: ['/ziti/quickstarts/quickstart-overview.html', '/ziti/quickstarts/networks-overview.html', '/docs/quickstarts'],
+            to: '/docs/learn/quickstarts/',
+            from: ['/ziti/quickstarts/quickstart-overview.html', '/ziti/quickstarts/networks-overview.html', '/docs/learn/quickstarts/network'],
           },
           {
             to: '/docs/learn/introduction/openziti-is-software',


### PR DESCRIPTION
category doc link to grandchild page causes confusing prev/next behavior because the button links are based on auto-generated sidebar item order