### PR TITLE
Miniziti no hosts

### DIFF
--- a/docusaurus/docs/learn/quickstarts/network/local-kubernetes.md
+++ b/docusaurus/docs/learn/quickstarts/network/local-kubernetes.md
@@ -173,8 +173,12 @@ sudo tee -a /etc/hosts <<< "$(minikube --profile miniziti ip) miniziti-controlle
 You can run the miniziti shell script or perform the steps manually yourself. Click the "Manual Steps" tab directly above to switch your view.
 
 It's recommended that you read the script before you run it. It's safe to re-run the script if it encounters a temporary problem.
+<br/>
 
-To run the script you'll need to [download the file](./miniziti.bash) and run it like this:
+[**DOWNLOAD: miniziti.bash**](./miniziti.bash)
+
+<br/>
+Be sure to complete the DNS setup steps above before running this command.
 
 ```bash
 bash ./miniziti.bash
@@ -232,7 +236,7 @@ CoreDNS is running at https://127.0.0.1:49439/api/v1/namespaces/kube-system/serv
 
 You will need two Minikube addons:
 
-1. `ingress`: installs the Nginx ingress controller. Ingresses provide access into the cluster and are the only things exposed to networks outside the cluster.
+1. `ingress`: installs the Nginx ingress controller. Ingresses provide access into the cluster and are the only things exposed to networks outside the cluster. This is required by the miniziti script, but the Helm charts can be configured to use other ingress controllers.
 1. `ingress-dns`: provides a DNS server that can answer queries about the cluster's ingresses, e.g. "miniziti-controller.ziti" which will be created when you install the OpenZiti Controller Helm chart.
 
 ```bash
@@ -620,26 +624,3 @@ Now that you've successfully tested the OpenZiti Service, check out the various 
    ```
 
 2. In your OpenZiti Tunneler, "Forget" your Identity.
-
-## minikube `ingress-dns` nameserver
-
-This option configures your host to use use the DNS addon we enabled earlier for DNS names like *.ziti. If you do this then you don't need to edit the `/etc/hosts` file at all.
-
-1. Make sure the DNS addon is working. Send a DNS query to the  address where the ingress nameserver is running.
-
-   ```bash
-   nslookup miniziti-controller.ziti $(minikube --profile miniziti ip)
-   ```
-
-   You know it's working if you see the same IP address in the response as when you run `minikube --profile miniziti ip`.
-
-1. Configure your computer to always send certain DNS queries to the `ingress-dns` nameserver. Follow the steps in [the `minikube` web site](https://minikube.sigs.k8s.io/docs/handbook/addons/ingress-dns/#installation) to configure macOS, Windows, or Linux's DNS resolver.
-
-   Now that your computer is set up to use the `minikube` DNS server for DNS names that end in *.ziti, you can test it again without specifying where to send the DNS query.
-
-   ```bash
-   # test your DNS configuration
-   nslookup miniziti-controller.ziti
-   ```
-
-   You know it's working if you see the same IP address in the response as when you run `minikube --profile miniziti ip`.

--- a/docusaurus/docs/learn/quickstarts/network/local-kubernetes.md
+++ b/docusaurus/docs/learn/quickstarts/network/local-kubernetes.md
@@ -554,7 +554,7 @@ nslookup httpbin.ziti
 curl -sSf -XPOST -d ziti=awesome http://httpbin.ziti/post | jq .data
 ```
 
-Visit [http://httpbin.ziti/get](http://httpbin.ziti/get) in your web browser in macOS, Linux, or Windows to see a JSON test response from the demo server.
+Visit [http://httpbin.miniziti/get](http://httpbin.miniziti/get) in your web browser in macOS, Linux, or Windows to see a JSON test response from the demo server.
 
 ## Explore the OpenZiti Console
 

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -32,7 +32,6 @@ _usage(){
             "   --verbose\t\tshow DEBUG messages\n"\
             "   --profile\t\tMINIKUBE_PROFILE (miniziti)\n"\
             "   --namespace\t\tZITI_NAMESPACE (MINIKUBE_PROFILE)\n"\
-            "   --no-hosts\t\tdon't use local hosts DB or ingress-dns nameserver\n"\
             "\n DEBUG\n"\
             "   --charts\t\tZITI_CHARTS_REF (openziti) alternative charts repo\n"\
             "   --now\t\teliminate safety waits, e.g., before deleting miniziti\n"\
@@ -278,7 +277,7 @@ main(){
     MINIKUBE_NODE_EXTERNAL=$(minikube --profile "${MINIKUBE_PROFILE}" ip)
     # if --no-hosts then build a new zone name for RFC-1918 wildcard DNS
     (( MINIZITI_HOSTS )) || {
-        MINIZITI_INGRESS_ZONE="${MINIKUBE_NODE_EXTERNAL}.mini.openziti.io"
+        MINIZITI_INGRESS_ZONE="${MINIKUBE_NODE_EXTERNAL}.sslip.io"
         logDebug "DNS wildcard zone for ingresses is ${MINIZITI_INGRESS_ZONE}"
     }
     if [[ -n "${MINIKUBE_NODE_EXTERNAL:-}" ]]; then

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -333,7 +333,7 @@ main(){
             --set trust-manager.app.trust.namespace="${ZITI_NAMESPACE}" \
             --set trust-manager.enabled=true \
             --set cert-manager.enabled=true \
-            --values https://openziti.io/helm-charts/charts/ziti-controller/values-ingress-nginx.yaml >&3
+            --values "${ZITI_CHARTS:-https://openziti.io/helm-charts/charts}/ziti-controller/values-ingress-nginx.yaml" >&3
     else
         logInfo "installing openziti controller"
         helm install "ziti-controller" "${ZITI_CHARTS}/ziti-controller" \
@@ -342,7 +342,7 @@ main(){
             --set trust-manager.app.trust.namespace="${ZITI_NAMESPACE}" \
             --set trust-manager.enabled=true \
             --set cert-manager.enabled=true \
-            --values https://openziti.io/helm-charts/charts/ziti-controller/values-ingress-nginx.yaml >&3
+            --values "${ZITI_CHARTS:-https://openziti.io/helm-charts/charts}/ziti-controller/values-ingress-nginx.yaml" >&3
     fi
 
     logDebug "setting default namespace '${ZITI_NAMESPACE}' in kubeconfig context '${MINIKUBE_PROFILE}'"
@@ -487,7 +487,7 @@ main(){
             --set edge.advertisedHost=miniziti-router.ziti \
             --set linkListeners.transport.advertisedHost=miniziti-router-transport.ziti \
             --set "ctrl.endpoint=ziti-controller-ctrl.${ZITI_NAMESPACE}.svc:443" \
-            --values https://openziti.io/helm-charts/charts/ziti-router/values-ingress-nginx.yaml >&3
+            --values "${ZITI_CHARTS:-https://openziti.io/helm-charts/charts}/ziti-router/values-ingress-nginx.yaml" >&3
     else
         logDebug "installing router chart as 'ziti-router'"
         helm install "ziti-router" "${ZITI_CHARTS}/ziti-router" \
@@ -496,7 +496,7 @@ main(){
             --set edge.advertisedHost=miniziti-router.ziti \
             --set linkListeners.transport.advertisedHost=miniziti-router-transport.ziti \
             --set "ctrl.endpoint=ziti-controller-ctrl.${ZITI_NAMESPACE}.svc:443" \
-            --values https://openziti.io/helm-charts/charts/ziti-router/values-ingress-nginx.yaml >&3
+            --values "${ZITI_CHARTS:-https://openziti.io/helm-charts/charts}/ziti-router/values-ingress-nginx.yaml" >&3
     fi
 
     logInfo "waiting for ziti-router to be ready"
@@ -525,14 +525,14 @@ main(){
             --namespace "${ZITI_NAMESPACE}" \
             --set ingress.advertisedHost=miniziti-console.ziti \
             --set "settings.edgeControllers[0].url=https://ziti-controller-client.${ZITI_NAMESPACE}.svc:443" \
-            --values https://openziti.io/helm-charts/charts/ziti-console/values-ingress-nginx.yaml >&3
+            --values "${ZITI_CHARTS:-https://openziti.io/helm-charts/charts}/ziti-console/values-ingress-nginx.yaml" >&3
     else
         logDebug "installing console chart as 'ziti-console'"
         helm install "ziti-console" "${ZITI_CHARTS}/ziti-console" \
             --namespace "${ZITI_NAMESPACE}" \
             --set ingress.advertisedHost=miniziti-console.ziti \
             --set "settings.edgeControllers[0].url=https://ziti-controller-client.${ZITI_NAMESPACE}.svc:443" \
-            --values https://openziti.io/helm-charts/charts/ziti-console/values-ingress-nginx.yaml >&3
+            --values "${ZITI_CHARTS:-https://openziti.io/helm-charts/charts}/ziti-console/values-ingress-nginx.yaml" >&3
     fi
 
     logInfo "waiting for ziti-console to be ready"

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -32,6 +32,7 @@ _usage(){
             "   --verbose\t\tshow DEBUG messages\n"\
             "   --profile\t\tMINIKUBE_PROFILE (miniziti)\n"\
             "   --namespace\t\tZITI_NAMESPACE (MINIKUBE_PROFILE)\n"\
+            "   --no-hosts\t\tdon't use local hosts DB or ingress-dns nameserver\n"\
             "\n DEBUG\n"\
             "   --charts\t\tZITI_CHARTS_REF (openziti) alternative charts repo\n"\
             "   --now\t\teliminate safety waits, e.g., before deleting miniziti\n"\

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -172,6 +172,7 @@ main(){
             DELETE_MINIZITI=0 \
             SAFETY_WAIT=1 \
             MINIKUBE_NODE_EXTERNAL \
+            ZITI_CHARTS_ALT=0 \
             ZITI_CHARTS_REF="openziti" \
             ZITI_CHARTS_URL="https://openziti.io/helm-charts/charts" \
             MINIZITI_HOSTS=1 \
@@ -201,6 +202,7 @@ main(){
             ;;
             --charts)       ZITI_CHARTS_REF="$2"
                             ZITI_CHARTS_URL="$2"
+                            ZITI_CHARTS_ALT=1
                             shift 2
             ;;
             -q|--quiet)     exec > /dev/null
@@ -364,7 +366,9 @@ main(){
             --values "${ZITI_CHARTS_URL}/ziti-controller/values-ingress-nginx.yaml" >&3
     else
         logInfo "installing openziti controller"
-        helm dependency build "${ZITI_CHARTS_REF}/ziti-controller" >&3
+        (( ZITI_CHARTS_ALT )) && {
+            helm dependency build "${ZITI_CHARTS_REF}/ziti-controller" >&3
+        }
         helm install "ziti-controller" "${ZITI_CHARTS_REF}/ziti-controller" \
             --namespace "${ZITI_NAMESPACE}" --create-namespace \
             --set clientApi.advertisedHost="miniziti-controller.${MINIZITI_INGRESS_ZONE}" \
@@ -521,7 +525,9 @@ main(){
             --values "${ZITI_CHARTS_URL}/ziti-router/values-ingress-nginx.yaml" >&3
     else
         logDebug "installing router chart as 'ziti-router'"
-        helm dependency build "${ZITI_CHARTS_REF}/ziti-router" >&3
+        (( ZITI_CHARTS_ALT )) && {
+            helm dependency build "${ZITI_CHARTS_REF}/ziti-router" >&3
+        }
         helm install "ziti-router" "${ZITI_CHARTS_REF}/ziti-router" \
             --namespace "${ZITI_NAMESPACE}" \
             --set-file enrollmentJwt=/tmp/miniziti-router.jwt \
@@ -560,7 +566,9 @@ main(){
             --values "${ZITI_CHARTS_URL}/ziti-console/values-ingress-nginx.yaml" >&3
     else
         logDebug "installing console chart as 'ziti-console'"
-        helm dependency build "${ZITI_CHARTS_REF}/ziti-console" >&3
+        (( ZITI_CHARTS_ALT )) && {
+            helm dependency build "${ZITI_CHARTS_REF}/ziti-console" >&3
+        }
         helm install "ziti-console" "${ZITI_CHARTS_REF}/ziti-console" \
             --namespace "${ZITI_NAMESPACE}" \
             --set ingress.advertisedHost="miniziti-console.${MINIZITI_INGRESS_ZONE}" \
@@ -684,7 +692,9 @@ main(){
 
     if [[ -s /tmp/httpbin-host.json ]]; then
         logDebug "installing httpbin chart as 'miniziti-httpbin'"
-        helm dependency build "${ZITI_CHARTS_REF}/httpbin" >&3
+        (( ZITI_CHARTS_ALT )) && {
+            helm dependency build "${ZITI_CHARTS_REF}/httpbin" >&3
+        }
         helm install "miniziti-httpbin" "${ZITI_CHARTS_REF}/httpbin" \
             --set-file zitiIdentity=/tmp/httpbin-host.json \
             --set zitiServiceName=httpbin-service >&3

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -65,7 +65,7 @@ deleteMiniziti(){
         logDebug "no integer param detected to deleteMiniziti(), using default wait time ${WAIT}s"
     fi
     (( SAFETY_WAIT )) && {
-        echo "WARN: deleting ${MINIKUBE_PROFILE} in ${WAIT}s" >&2
+        logWarn "deleting ${MINIKUBE_PROFILE} in ${WAIT}s" >&2
         sleep "$WAIT"
     }
     logInfo "waiting for ${MINIKUBE_PROFILE} to be deleted"

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -32,7 +32,7 @@ _usage(){
             "   --verbose\t\tshow DEBUG messages\n"\
             "   --profile\t\tMINIKUBE_PROFILE (miniziti)\n"\
             "   --namespace\t\tZITI_NAMESPACE (MINIKUBE_PROFILE)\n"\
-            "   --no-dns\t\tdon't use local hosts DB or ingress-dns nameserver\n"\
+            "   --no-hosts\t\tdon't use local hosts DB or ingress-dns nameserver\n"\
             "\n DEBUG\n"\
             "   --charts\t\tZITI_CHARTS (openziti) alternative charts repo\n"\
             "   --now\t\teliminate safety waits, e.g., before deleting miniziti\n"\


### PR DESCRIPTION
avoid adding hostnames in /etc/hosts or setting up the ingress-dns nameserver or host resolver configuration by using global RFC-1918 wildcard zone. This option `--no-hosts` creates a new dependence on internet availability for miniziti because all Ziti software needs to be able to send DNS queries to the internet nameservers for mini.openziti.io.