### PR TITLE
Feature/multi profile support

### DIFF
--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -97,7 +97,7 @@ detectOs(){
 
 makeMinizitiStateDir() {
     case "$DETECTED_OS" in
-        MacOS)
+        macOS)
             state_dir="${XDG_STATE_DIR:-$HOME/Library/Application Support}/miniziti"
             ;;
         Linux|Windows)
@@ -224,16 +224,17 @@ logger() {
     fi
 
     caller_level="${caller##log}"
+    level="$(echo "$caller_level" | tr '[:lower:]' '[:upper:]')"
     if (( MINIZITI_DEBUG )); then
-        line="${caller_level^^} ${FUNCNAME[2]}:${BASH_LINENO[1]}: $message"
+        line="$level ${FUNCNAME[2]}:${BASH_LINENO[1]}: $message"
     else
-        line="${caller_level^^} $message"
+        line="$level $message"
     fi
 
     if [[ -n "${raw_message-}" ]]; then
-        echo -E "${line}"
+        echo -E "$line"
     else
-        echo -e "${line}"
+        echo -e "$line"
     fi
 }
 

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -29,8 +29,8 @@ _usage(){
     echo -e "\n COMMANDS\n"\
             "   start\t\tstart miniziti (default)\n"\
             "   delete\t\tdelete miniziti\n"\
+            "   creds\t\tprints admin user updb credentials\n"\
             "   login\t\trun ziti edge login with miniziti context\n"\
-            "   admin-creds\t\tprints admin user updb credentials\n"\
             "   ziti\t\tziti cli wrapper with miniziti context\n"\
             "   help\t\tshow these usage hints\n"\
             "\n OPTIONS\n"\
@@ -293,10 +293,10 @@ main(){
             delete)         DELETE_MINIZITI=1
                             shift
             ;;
-            login)          DO_ZITI_LOGIN=1
+            creds)          SHOW_ADMIN_CREDS=1
                             shift
             ;;
-            admin-creds)     SHOW_ADMIN_CREDS=1
+            login)          DO_ZITI_LOGIN=1
                             shift
             ;;
             ziti)           RUN_ZITI_CLI=1

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -96,21 +96,15 @@ detectOs(){
 }
 
 makeMinizitiStateDir() {
-    local detected_os="$1"
-
-    case "$detected_os" in
+    case "$DETECTED_OS" in
         MacOS)
             state_dir="${XDG_STATE_DIR:-$HOME/Library/Application Support}/miniziti"
             ;;
-        Linux)
+        Linux|Windows)
             state_dir="${XDG_STATE_DIR:-$HOME/.local/state}/miniziti"
             ;;
-        Windows)
-            wsl_state_dir="${XDG_STATE_DIR:-$HOME/.local/state}/miniziti"
-            state_dir="$(wslpath -w "$wsl_state_dir")"
-            ;;
         *)
-            logError "Unknown os: $detected_os"
+            logError "Unknown os: $DETECTED_OS"
             exit 1
     esac
 
@@ -120,6 +114,14 @@ makeMinizitiStateDir() {
     fi
 
     echo "$state_dir"
+}
+
+pathToNative() {
+    local path="$1"
+    case "$DETECTED_OS" in
+        Windows) wslpath -w "$path" ;;
+        *) echo "$path" ;;
+    esac
 }
 
 testClusterDns(){
@@ -365,7 +367,7 @@ main(){
 
     MINIZITI_PROFILE_MARKER="miniziti-controller.$MINIKUBE_PROFILE."
     MINIZITI_INGRESS_ZONE="$MINIKUBE_PROFILE.ziti"
-    STATE_DIR="$(makeMinizitiStateDir "$DETECTED_OS")"
+    STATE_DIR="$(makeMinizitiStateDir)"
     PROFILE_DIR="$STATE_DIR/profiles/${MINIKUBE_PROFILE}"
     IDENTITIES_DIR="$PROFILE_DIR/identities"
 
@@ -880,7 +882,7 @@ main(){
     showAdminCreds
     echo -e "\n\n"
 
-    logInfo "Success! Remember to add your edge client identity '$CLIENT_OTT' in your tunneler, e.g. Ziti Desktop Edge."
+    logInfo "Success! Remember to add your edge client identity '$(pathToNative "$CLIENT_OTT")' in your tunneler, e.g. Ziti Desktop Edge."
 }
 
 main "$@"

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -231,11 +231,10 @@ logger() {
     fi
 
     caller_level="${caller##log}"
-    level="$(echo "$caller_level" | tr '[:lower:]' '[:upper:]')"
     if (( MINIZITI_DEBUG )); then
-        line="$level ${FUNCNAME[2]}:${BASH_LINENO[1]}: $message"
+        line="${caller_level^^} ${FUNCNAME[2]}:${BASH_LINENO[1]}: $message"
     else
-        line="$level $message"
+        line="${caller_level^^} $message"
     fi
 
     if [[ -n "${raw_message-}" ]]; then
@@ -429,7 +428,10 @@ main(){
             rm -rf  "$PROFILE_DIR"
         fi
 
-        CERT_FILE="$(find "$ZITI_CLI_CERTS_DIR" -maxdepth 1 -type f -name "miniziti-controller.$MINIKUBE_PROFILE.*" -print -quit)"
+        # This is best effort, when '--no-hosts' is specified,
+        # the right file is unknown due to the way the cli names the file,
+        # and we don't store enough state to recover it at this time.
+        CERT_FILE="$(find "$ZITI_CLI_CERTS_DIR" -maxdepth 1 -type f -name "miniziti-controller.$MINIKUBE_PROFILE.*" -print -quit 2> /dev/null)"
         if [[ -n "$CERT_FILE" ]]; then
             logWarn "Deleting miniziti certificate file: $CERT_FILE"
             rm -f  "$CERT_FILE"

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -30,7 +30,7 @@ _usage(){
             "   start\t\tstart miniziti (default)\n"\
             "   delete\t\tdelete miniziti\n"\
             "   login\t\trun ziti edge login with miniziti context\n"\
-            "   show-admin\t\tprints admin user updb credentials\n"\
+            "   admin-creds\t\tprints admin user updb credentials\n"\
             "   ziti\t\tziti cli wrapper with miniziti context\n"\
             "   help\t\tshow these usage hints\n"\
             "\n OPTIONS\n"\
@@ -95,7 +95,7 @@ detectOs(){
     fi
 }
 
-makeMinizitiXDGStateDir() {
+makeMinizitiStateDir() {
     local detected_os="$1"
 
     case "$detected_os" in
@@ -294,7 +294,7 @@ main(){
             login)          DO_ZITI_LOGIN=1
                             shift
             ;;
-            show-admin)     SHOW_ADMIN_CREDS=1
+            admin-creds)     SHOW_ADMIN_CREDS=1
                             shift
             ;;
             ziti)           RUN_ZITI_CLI=1
@@ -365,7 +365,7 @@ main(){
 
     MINIZITI_PROFILE_MARKER="miniziti-controller.$MINIKUBE_PROFILE."
     MINIZITI_INGRESS_ZONE="$MINIKUBE_PROFILE.ziti"
-    STATE_DIR="$(makeMinizitiXDGStateDir "$DETECTED_OS")"
+    STATE_DIR="$(makeMinizitiStateDir "$DETECTED_OS")"
     PROFILE_DIR="$STATE_DIR/profiles/${MINIKUBE_PROFILE}"
     IDENTITIES_DIR="$PROFILE_DIR/identities"
 

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -266,6 +266,7 @@ helm_wrapper() {
 }
 
 main(){
+    MINIZITI_DEBUG=0
     # require commands
     declare -a BINS=(ziti minikube kubectl helm sed)
     for BIN in "${BINS[@]}"; do
@@ -284,9 +285,7 @@ main(){
             DO_ZITI_LOGIN=0 \
             MINIKUBE_NODE_EXTERNAL \
             MINIKUBE_PROFILE="miniziti" \
-            MINIZITI_DEBUG=0 \
             MINIZITI_HOSTS=1 \
-            MINIZITI_INTERCEPT_ZONE="miniziti" \
             MINIZITI_MODIFY_HOSTS=0 \
             RUN_ZITI_CLI=0 \
             SAFETY_WAIT=1 \
@@ -384,7 +383,8 @@ main(){
     : "${ZITI_NAMESPACE:=${MINIKUBE_PROFILE}}"
 
     MINIZITI_PROFILE_MARKER="# miniziti:profile:$MINIKUBE_PROFILE"
-    MINIZITI_INGRESS_ZONE="$MINIKUBE_PROFILE.ziti"
+    MINIZITI_INGRESS_ZONE="$MINIKUBE_PROFILE.internal"
+    MINIZITI_INTERCEPT_ZONE="$MINIKUBE_PROFILE.private" \
     STATE_DIR="$(makeMinizitiStateDir)"
     PROFILE_DIR="$STATE_DIR/profiles/${MINIKUBE_PROFILE}"
     IDENTITIES_DIR="$PROFILE_DIR/identities"

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -116,6 +116,13 @@ makeMinizitiStateDir() {
     echo "$state_dir"
 }
 
+getZitiCliHome() {
+    case "$DETECTED_OS" in
+        Linux) echo "$HOME/.config/ziti" ;;
+        *) echo "$HOME/.ziti" ;;
+    esac
+}
+
 pathToNative() {
     local path="$1"
     case "$DETECTED_OS" in
@@ -385,7 +392,9 @@ main(){
 
     MINIZITI_PROFILE_MARKER="# miniziti:profile:$MINIKUBE_PROFILE"
     MINIZITI_INGRESS_ZONE="$MINIKUBE_PROFILE.internal"
-    MINIZITI_INTERCEPT_ZONE="$MINIKUBE_PROFILE.private" \
+    MINIZITI_INTERCEPT_ZONE="$MINIKUBE_PROFILE.private"
+    ZITI_CLI_HOME="$(getZitiCliHome)"
+    ZITI_CLI_CERTS_DIR="$ZITI_CLI_HOME/certs"
     STATE_DIR="$(makeMinizitiStateDir)"
     PROFILE_DIR="$STATE_DIR/profiles/${MINIKUBE_PROFILE}"
     IDENTITIES_DIR="$PROFILE_DIR/identities"
@@ -420,7 +429,7 @@ main(){
             rm -rf  "$PROFILE_DIR"
         fi
 
-        CERT_FILE="$(find "$HOME/.config/ziti/certs" -maxdepth 1 -type f -name "miniziti-controller.$MINIKUBE_PROFILE.*" -print -quit)"
+        CERT_FILE="$(find "$ZITI_CLI_CERTS_DIR" -maxdepth 1 -type f -name "miniziti-controller.$MINIKUBE_PROFILE.*" -print -quit)"
         if [[ -n "$CERT_FILE" ]]; then
             logWarn "Deleting miniziti certificate file: $CERT_FILE"
             rm -f  "$CERT_FILE"

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -210,16 +210,30 @@ miniziti_login() {
 
 logger() {
     local caller="${FUNCNAME[1]}"
+
     if (( $# < 1 )); then
         echo "ERROR: $caller() takes 1 or more args" >&2
         return 1
     fi
 
+    local message="$*"
+
+    if [[ "$message" =~ ^r\'(.+)\'$ ]]; then
+        raw_message="${BASH_REMATCH[1]}"
+        message="$raw_message"
+    fi
+
     caller_level="${caller##log}"
     if (( MINIZITI_DEBUG )); then
-        echo -e "${caller_level^^} ${FUNCNAME[2]}:${BASH_LINENO[1]}: $*"
+        line="${caller_level^^} ${FUNCNAME[2]}:${BASH_LINENO[1]}: $message"
     else
-        echo -e "${caller_level^^} $*"
+        line="${caller_level^^} $message"
+    fi
+
+    if [[ -n "${raw_message-}" ]]; then
+        echo -E "${line}"
+    else
+        echo -e "${line}"
     fi
 }
 
@@ -882,7 +896,7 @@ main(){
     showAdminCreds
     echo -e "\n\n"
 
-    logInfo "Success! Remember to add your edge client identity '$(pathToNative "$CLIENT_OTT")' in your tunneler, e.g. Ziti Desktop Edge."
+    logInfo "r'Success! Remember to add your edge client identity '$(pathToNative "$CLIENT_OTT")' in your tunneler, e.g. Ziti Desktop Edge.'"
 }
 
 main "$@"

--- a/docusaurus/docs/learn/quickstarts/network/miniziti.bash
+++ b/docusaurus/docs/learn/quickstarts/network/miniziti.bash
@@ -159,20 +159,20 @@ HOSTS_FILE='/etc/hosts'
 cleanHosts() {
     logWarn "Removing stale miniziti entries from $HOSTS_FILE"
     if (( EUID != 0 )); then
-        sudo sed -i "/${MINIZITI_PROFILE_MARKER}/d" "$HOSTS_FILE"
+        sudo sed -i "/$MINIZITI_PROFILE_MARKER/d" "$HOSTS_FILE"
     else
-        sed -i "/${MINIZITI_PROFILE_MARKER}/d" "$HOSTS_FILE"
+        sed -i "/$MINIZITI_PROFILE_MARKER/d" "$HOSTS_FILE"
     fi
 }
 
 installHosts() {
     hosts=(
-        "miniziti-controller.${MINIZITI_INGRESS_ZONE}"
-        "miniziti-router.${MINIZITI_INGRESS_ZONE}"
-        "miniziti-console.${MINIZITI_INGRESS_ZONE}"
+        "miniziti-controller.$MINIZITI_INGRESS_ZONE"
+        "miniziti-router.$MINIZITI_INGRESS_ZONE"
+        "miniziti-console.$MINIZITI_INGRESS_ZONE"
     )
 
-    hosts_line="${MINIKUBE_NODE_EXTERNAL} ${hosts[*]}"
+    hosts_line="$MINIKUBE_NODE_EXTERNAL ${hosts[*]} $MINIZITI_PROFILE_MARKER"
 
     if ! grep -q "$hosts_line" "$HOSTS_FILE"; then
 
@@ -193,7 +193,7 @@ installHosts() {
 
 getAdminSecret() {
     kubectl_wrapper get secrets "ziti-controller-admin-secret" \
-        --namespace "${ZITI_NAMESPACE}" \
+        --namespace "$ZITI_NAMESPACE" \
         --output go-template='{{index .data "admin-password" | base64decode }}'
 }
 
@@ -365,7 +365,7 @@ main(){
 
     : "${ZITI_NAMESPACE:=${MINIKUBE_PROFILE}}"
 
-    MINIZITI_PROFILE_MARKER="miniziti-controller.$MINIKUBE_PROFILE."
+    MINIZITI_PROFILE_MARKER="# miniziti:profile:$MINIKUBE_PROFILE"
     MINIZITI_INGRESS_ZONE="$MINIKUBE_PROFILE.ziti"
     STATE_DIR="$(makeMinizitiStateDir)"
     PROFILE_DIR="$STATE_DIR/profiles/${MINIKUBE_PROFILE}"


### PR DESCRIPTION
This PR attempts to deliver on the Miniziti promise of multiple Ziti profile support. To support that, this PR additionally adds some useful (context-aware) utility commands helpful in a multi-profile paradigm.

Features:
* `login` command
* `show-admin` command
* `ziti` command wrapper
* XDG-based per-profile namespacing
* Richer logging
* Idempotent management of `/etc/hosts` entries