### PR TITLE
Fix the "Quickstart Guides" in Introduction page.

### DIFF
--- a/docusaurus/docs/learn/introduction/index.mdx
+++ b/docusaurus/docs/learn/introduction/index.mdx
@@ -28,4 +28,4 @@ import {WhatIsOpenZiti} from "../../../src/components/SharedComponents";
 OpenZiti makes it **easy** to embed zero trust, programmable networking directly into your app. With OpenZiti you can have **zero trust, high performance networking on any Internet connection**, without VPNs!
 
 :running: Ready to deploy your first network? Jump right in, feet first, and follow along with one of our
-[quickstart guides](/docs/learn/quickstarts/network)!
+[quickstart guides](/docs/category/network)!


### PR DESCRIPTION
The link for `Quickstart Guides` is currently pointing at `/docs/learn/quickstarts/network` which does not exist. The small change here is fixing that link by pointing it to `/docs/category/network` instead. This is aligned with the navigation links.