### PR TITLE
link to the available SDKs

### DIFF
--- a/docusaurus/docs/learn/introduction/30-openziti-is-software.md
+++ b/docusaurus/docs/learn/introduction/30-openziti-is-software.md
@@ -78,6 +78,8 @@ fulcrum to leverage the power of an OpenZiti Network.
 The SDKs expose an API that allows endpoints to enroll, authenticate, list services, receive centralized configuration,
 and connect or host services based on security access configuration.
 
+[Check out the SDKs](/reference/developer/sdk/index.mdx).
+
 ## Clients
 
 OpenZiti clients are any code that uses an OpenZiti SDK to connect to an OpenZiti Network. The OpenZiti project can provide these


### PR DESCRIPTION
openziti.io landing page and netfoundry.io/downloads both link to the "it's all software" section about SDKs, so that section needs to link to the SDK references so that the interested reader can learn more.