### PR TITLE
pages/appetizer: fix missing command in codeToCopy

### DIFF
--- a/docusaurus/src/pages/appetizer/index.js
+++ b/docusaurus/src/pages/appetizer/index.js
@@ -88,6 +88,7 @@ function App() {
 
     const codeToCopy = `
         git clone https://github.com/openziti-test-kitchen/appetizer.git
+        cd appetizer
         go run clients/reflect.go reflectService
         `;
     const trimmedCode = codeToCopy


### PR DESCRIPTION
The code to copy doesn't work, because the user needs to enter the directory of the cloned repo before go can see what it should build