### PR TITLE
console cert auth

### DIFF
--- a/docusaurus/docs/guides/deployments/10-linux/30-console.mdx
+++ b/docusaurus/docs/guides/deployments/10-linux/30-console.mdx
@@ -3,6 +3,8 @@ title: Console Deployment
 sidebar_label: Console
 ---
 
+import ConsoleAuthAdminClientCertificate from '/docs/reference/40-command-line/_console-auth-admin-client-certificate.mdx';
+
 ## Installation
 
 ### Install the Package
@@ -60,3 +62,7 @@ Console versions >= 3.0.0 from GitHub may be used.
     ```
 
 1. Console certificate option - The console is served from the controller's API and can be used with the default API certificate. The controller can be configured to present a different certificate for the console when the API is accessed by a distinct URL for the console. For more information about using alternative server certs with the controller, see: [the configuration reference for the `identity` property](/reference/30-configuration/conventions.md#identity).
+
+## Authenticate with an Admin Client Certificate
+
+<ConsoleAuthAdminClientCertificate />

--- a/docusaurus/docs/guides/deployments/20-docker/30-console.mdx
+++ b/docusaurus/docs/guides/deployments/20-docker/30-console.mdx
@@ -3,6 +3,8 @@ title: Deploy the Console
 sidebar_label: Console
 ---
 
+import ConsoleAuthAdminClientCertificate from '/docs/reference/40-command-line/_console-auth-admin-client-certificate.mdx';
+
 This article is about enabling the console on a controller that is running in a container.
 
 1. Configure the controller
@@ -63,3 +65,7 @@ The controller container includes the latest version of the console. You can ins
     ```text
     docker compose up ziti-controller --force-recreate
     ```
+
+## Authenticate with an Admin Client Certificate
+
+<ConsoleAuthAdminClientCertificate />

--- a/docusaurus/docs/guides/deployments/30-kubernetes/kubernetes-console.mdx
+++ b/docusaurus/docs/guides/deployments/30-kubernetes/kubernetes-console.mdx
@@ -4,6 +4,10 @@ sidebar_label: Console
 title: Kubernetes Console
 ---
 
+import ConsoleAuthAdminClientCertificate from '/docs/reference/40-command-line/_console-auth-admin-client-certificate.mdx';
+
+## Find the Console URL
+
 Use the console by navigating to the controller's address with path `/zac/` in a web browser. If you published the controller at `ctrl.ziti.example.com:443`, then the console URL is `https://ctrl.ziti.example.com/zac/`.
 
 The correct console URL is displayed after Helm install or upgrade and may be fetched at any time with Helm.
@@ -12,23 +16,7 @@ The correct console URL is displayed after Helm install or upgrade and may be fe
 helm get notes "ziti-controller"
 ```
 
-```buttonless title="Output"
-NOTES:
-
-Your release ziti-controller was upgraded.
-
-
-You have chart version 1.0.10 and app version 1.1.3.
-
-To learn more about the release, try:
-
-  $ helm status ziti-controller -n miniziti
-  $ helm get all ziti-controller -n miniziti
-
-This deployment provides an OpenZiti controller to manage an OpenZiti network.
-
-Visit the console in a web browser: https://ctrl.ziti.example.com:443/zac/
-```
+## Authenticate with a Username and Password
 
 ```text title="Print the username and password"
 kubectl get secrets ziti-controller-admin-secret \
@@ -42,3 +30,7 @@ kubectl get secrets ziti-controller-admin-secret \
 admin-password: UJ2Z4xK1OpagXG94GkAXkR0M4MRNvcOh
 admin-user: admin
 ```
+
+## Authenticate with an Admin Client Certificate
+
+<ConsoleAuthAdminClientCertificate />

--- a/docusaurus/docs/reference/40-command-line/_console-auth-admin-client-certificate.mdx
+++ b/docusaurus/docs/reference/40-command-line/_console-auth-admin-client-certificate.mdx
@@ -1,0 +1,29 @@
+
+
+1. Enroll an admin identity. [Link to instructions](/reference/40-command-line/login.mdx)
+1. Unwrap the JSON file to obtain the certificate and private key.
+
+    ```text
+    ziti ops unwrap admin2.json
+    ```
+
+1. Compose a keystore from the certificate and private key. The `-legacy` flag is necessary when importing the keystore into some versions of macOS Keychain Access.
+
+    ```text
+    openssl pkcs12 -export -in admin2.cert -inkey admin2.key -out admin2.p12 -name "admin2" -legacy -password 'pass:mypassword'
+    ```
+
+1. Import the keystore:
+
+    * macOS: Import into System Keychain via Keychain Access application for Google Chrome. You can run a terminal command or double-click the keystore file or drag it onto the login keychain to import it.
+
+        ```text
+        security import admin2.p12 -k ~/Library/Keychains/login.keychain -T /Applications/Google\ Chrome.app -P 'mypass'
+        ```
+
+    * Windows: Import into the Windows Certificate Store (Personal store) via certmgr.msc.
+    * Linux: Import into your browser's certificate store or system certificate store (e.g., Chrome Settings > Privacy and Security > Security > Manage certificates).
+
+1. Visit the console in your web browser. The browser will prompt with a list of imported client certificates. Select the one you imported in the previous step.
+
+1. Press the "LOGIN" button without entering a password.


### PR DESCRIPTION
Add a section about logging in to the console with a browser client cert in places where console password auth is already described.