### PR TITLE
remove workarounds for controller / router helm charts

### DIFF
--- a/gendoc.sh
+++ b/gendoc.sh
@@ -28,19 +28,6 @@ fix_helm_ziti_edge_tunnel() {
   sed -i 's#sresponse\\\\s<|>\$#sresponse\\\\s\&lt;|>\$#g' "$_target"
 }
 
-fix_helm_ziti_controller() {
-  local _target="${ZITI_DOC_GIT_LOC}/helm-charts/charts/ziti-controller/README.md"
-  echo "fixing $_target to work with docusaurus"
-  sed -i 's/{release}/\&lbrace;release}/g' "$_target"
-  sed -i 's/{namespace}/\&lbrace;namespace}/g' "$_target"
-  sed -i 's/{port}/\&lbrace;port}/g' "$_target"
-}
-
-fix_helm_ziti_router() {
-  local _target="${ZITI_DOC_GIT_LOC}/helm-charts/charts/ziti-router/README.md"
-  echo "fixing $_target to work with docusaurus"
-  sed -i 's/{{ release }}/\&lbrace;\&lbrace; release }}/g' "$_target"
-}
 
 set -e
 
@@ -105,8 +92,6 @@ if [[ "${SKIP_GIT}" == no ]]; then
   clone_or_pull "https://github.com/openziti/desktop-edge-win" "desktop-edge-win" >/dev/null
 
   fix_helm_ziti_edge_tunnel
-  fix_helm_ziti_controller
-  fix_helm_ziti_router
 fi
 
 if [[ "${SKIP_CLEAN}" == no ]]; then


### PR DESCRIPTION
As a result of a workaround with unescaped braces in the controller helm chart documentation, the docs currently render some garbled output:
![image](https://github.com/user-attachments/assets/28b63ce7-8354-47a8-bb14-c8bad04f95f1)

This PR removes the workaround - depends on merging of https://github.com/openziti/helm-charts/pull/298.


