### PR TITLE
move gendoc's _remotes inside /doc to traverse full MDX pipeline...

### DIFF
--- a/docusaurus/.gitignore
+++ b/docusaurus/.gitignore
@@ -19,8 +19,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-_remotes
-remotes
-all/docs/_remotes
+/docs/_remotes
 ziti
 static/docs/reference/developer/sdk

--- a/docusaurus/docs/guides/deployments/20-docker/10-controller.mdx
+++ b/docusaurus/docs/guides/deployments/20-docker/10-controller.mdx
@@ -3,6 +3,6 @@ title: Deploy the Controller with Docker
 sidebar_label: Controller
 ---
 
-import DockerControllerReadme from '/_remotes/ziti-cmd/dist/docker-images/ziti-controller/README.md';
+import DockerControllerReadme from '/docs/_remotes/ziti-cmd/dist/docker-images/ziti-controller/README.md';
 
 <DockerControllerReadme />

--- a/docusaurus/docs/guides/deployments/20-docker/20-router.mdx
+++ b/docusaurus/docs/guides/deployments/20-docker/20-router.mdx
@@ -3,6 +3,6 @@ title: Deploy the Router with Docker
 sidebar_label: Router
 ---
 
-import DockerRouterReadme from '/_remotes/ziti-cmd/dist/docker-images/ziti-router/README.md';
+import DockerRouterReadme from '/docs/_remotes/ziti-cmd/dist/docker-images/ziti-router/README.md';
 
 <DockerRouterReadme />

--- a/docusaurus/docs/guides/deployments/30-kubernetes/kubernetes-controller.mdx
+++ b/docusaurus/docs/guides/deployments/30-kubernetes/kubernetes-controller.mdx
@@ -4,6 +4,6 @@ sidebar_label: Controller
 title: Install the Controller in Kubernetes
 ---
 
-import ControllerHelmChartReadme from '/_remotes/helm-charts/charts/ziti-controller/README.md';
+import ControllerHelmChartReadme from '/docs/_remotes/helm-charts/charts/ziti-controller/README.md';
 
 <ControllerHelmChartReadme/>

--- a/docusaurus/docs/guides/deployments/30-kubernetes/kubernetes-router.mdx
+++ b/docusaurus/docs/guides/deployments/30-kubernetes/kubernetes-router.mdx
@@ -4,6 +4,6 @@ sidebar_label: Router
 title: Install the Router in Kubernetes
 ---
 
-import RouterHelmChartReadme from '/_remotes/helm-charts/charts/ziti-router/README.md';
+import RouterHelmChartReadme from '/docs/_remotes/helm-charts/charts/ziti-router/README.md';
 
 <RouterHelmChartReadme/>

--- a/docusaurus/docs/learn/formatting-demo.mdx
+++ b/docusaurus/docs/learn/formatting-demo.mdx
@@ -118,3 +118,23 @@ regular, text here
 <DetailsExample/>
 
 :::
+
+
+## GitHub Markdown Examples
+
+A ReMark plugin translates imported GitHub admonitions to Docusaurus admonitions. Read more about [importing GitHub Markdown](/learn/formatting-demo2.mdx#import-github-markdown).
+
+> [!NOTE]
+> <DetailsExample/>
+
+> [!TIP]
+> <DetailsExample/>
+
+> [!IMPORTANT]
+> <DetailsExample/>
+
+> [!WARNING]
+> <DetailsExample/>
+
+> [!CAUTION]
+> <DetailsExample/>

--- a/docusaurus/docs/learn/formatting-demo2.mdx
+++ b/docusaurus/docs/learn/formatting-demo2.mdx
@@ -199,3 +199,47 @@ echo "Inside admonition, inside details"
 - [x] HTML buttons
 - [x] `<details>` block
 
+## Import GitHub Markdown
+
+You can import Markdown from other repositories, e.g., README.md, by adding the Git remote to `gendoc.sh`, then importing the Markdown with the `import` component from the correlated path within the `_remotes` directory.
+
+```md
+import SomeMd from '/docs/_remotes/some-remote/README.md';
+
+<SomeMd />
+```
+
+See GitHub Markdown admonition examples in the [Code Block Formatting Demo](/learn/formatting-demo.mdx#github-markdown-examples)
+
+### When to Use the MarkdownWithoutH1 Component with Imported Markdown
+
+When importing GitHub Markdown as MDX, you have two choices for the H1 page title: use the title from the imported Markdown or set an alternative title. 
+
+Typically, setting any title in Docsaurus will display both, even if `title` is not set in the front matter, because the default title is the page name.
+
+To use the imported title, set `hide_title: true` in front matter to hide the Docusaurus title.
+
+```yaml
+---
+hide_title: true
+---
+
+import SomeMd from '/docs/_remotes/some-remote/README.md';
+
+<SomeMd />
+```
+
+To hide the imported title and use the Docusaurus title, set `hide_title: false`, `title: My Alt Title`, and enclose the imported Markdown with `<MarkdownWithoutH1>`.
+
+```yaml
+---
+title: A Descriptive Title 
+---
+
+import SomeMd from '/docs/_remotes/some-remote/README.md';
+import MarkdownWithoutH1 from '@site/src/components/MarkdownWithoutH1';
+
+<MarkdownWithoutH1>
+<SomeMd />
+</MarkdownWithoutH1>
+```

--- a/docusaurus/docs/reference/developer/sdk/android.mdx
+++ b/docusaurus/docs/reference/developer/sdk/android.mdx
@@ -1,10 +1,13 @@
 ---
-hide_title: true
-title: Android
+title: Ziti Android Quickstart
+sidebar_label: Android
 hide_table_of_contents: false
 toc_min_heading_level: 3
 ---
-import AndroidMd from '../../../../_remotes/ziti-android-app/README.md';
 
-<AndroidMd />
+import AndroidMd from '/docs/_remotes/ziti-android-app/README.md';
+import MarkdownWithoutH1 from '@site/src/components/MarkdownWithoutH1';
 
+<MarkdownWithoutH1>
+    <AndroidMd />
+</MarkdownWithoutH1>

--- a/docusaurus/docs/reference/ha/bootstrapping/certificates.md
+++ b/docusaurus/docs/reference/ha/bootstrapping/certificates.md
@@ -32,6 +32,7 @@ A [trust domain](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/#tru
 
 1. The certificates must have a shared root of trust
 1. The controller client and server certificates must contain a SPIFFE ID.
+1. The controller client certificate's Common Name must exactly match the controller ID part of the SPIFFE ID.
 1. The SPIFFE ID must be set as the only URI in the `X509v3 Subject Alternative Name` field in the
    certificate.
 1. The SPIFFE ID must have the following format: `spiffe://<trust domain>/controller/<controller id>`

--- a/docusaurus/docs/reference/tunnelers/60-linux/10-debian-package.mdx
+++ b/docusaurus/docs/reference/tunnelers/60-linux/10-debian-package.mdx
@@ -50,8 +50,6 @@ curl -sSLf https://get.openziti.io/tun/scripts/install-ubuntu.bash | bash
 | 13 Trixie   | jammy        | x86_64, arm64 |
 | 12 Bookworm | jammy        | x86_64, arm64 |
 | 11 Bullseye | focal        | x86_64, arm64 |
-| 10 Buster   | bionic       | x86_64        |
-|  9 Stretch  | xenial       | x86_64        |
 
 1. Refer to the table to find the Ubuntu release name that is the contemporary of the Debian release. Substitute the Ubuntu release name for `jammy` in the `/etc/apt/sources.list.d/openziti.list` file.
 

--- a/docusaurus/docs/reference/tunnelers/70-docker/readme.mdx
+++ b/docusaurus/docs/reference/tunnelers/70-docker/readme.mdx
@@ -1,9 +1,12 @@
 ---
-#hide_title: true
-title: Containers
+title: Run The Tunneler with Docker
+sidebar_label: Docker
 hide_table_of_contents: false
 ---
 
-import DockerMd from '/_remotes/ziti-tunnel-sdk-c/docker/README.md';
+import DockerMd from '/docs/_remotes/ziti-tunnel-sdk-c/docker/README.md';
+import MarkdownWithoutH1 from '@site/src/components/MarkdownWithoutH1';
 
-<DockerMd />
+<MarkdownWithoutH1>
+    <DockerMd />
+</MarkdownWithoutH1>

--- a/docusaurus/docs/reference/tunnelers/80-kubernetes/kubernetes-daemonset.mdx
+++ b/docusaurus/docs/reference/tunnelers/80-kubernetes/kubernetes-daemonset.mdx
@@ -4,6 +4,9 @@ sidebar_label: Node Proxy
 sidebar_position: 70
 ---
 
-import TunHelmChartReadme from '/_remotes/helm-charts/charts/ziti-edge-tunnel/README.md';
+import TunHelmChartReadme from '/docs/_remotes/helm-charts/charts/ziti-edge-tunnel/README.md';
+import MarkdownWithoutH1 from '@site/src/components/MarkdownWithoutH1';
 
-<TunHelmChartReadme/>
+<MarkdownWithoutH1>
+    <TunHelmChartReadme/>
+</MarkdownWithoutH1>

--- a/docusaurus/docs/reference/tunnelers/80-kubernetes/kubernetes-host.mdx
+++ b/docusaurus/docs/reference/tunnelers/80-kubernetes/kubernetes-host.mdx
@@ -1,9 +1,12 @@
 ---
-sidebar_position: 60
-sidebar_label: Reverse Proxy Pod
 title: Deploy a Hosting Tunneler in Kubernetes
+sidebar_label: Reverse Proxy Pod
+sidebar_position: 60
 ---
 
-import HostHelmChartReadme from '/_remotes/helm-charts/charts/ziti-host/README.md';
+import HostHelmChartReadme from '/docs/_remotes/helm-charts/charts/ziti-host/README.md';
+import MarkdownWithoutH1 from '@site/src/components/MarkdownWithoutH1';
 
-<HostHelmChartReadme/>
+<MarkdownWithoutH1>
+    <HostHelmChartReadme/>
+</MarkdownWithoutH1>

--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -250,8 +250,12 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
+          exclude: [
+            '**/_*.{js,jsx,ts,tsx,md,mdx}',
+            '**/*.test.{js,jsx,ts,tsx}',
+            '**/__tests__/**',
+            '**/_remotes/**'
+          ],
           editUrl: 'https://github.com/openziti/ziti-doc/tree/main/docusaurus',
           beforeDefaultRemarkPlugins: [remarkGithubAdmonitionsToDirectives, ],
           remarkPlugins: [

--- a/docusaurus/src/components/MarkdownWithoutH1.js
+++ b/docusaurus/src/components/MarkdownWithoutH1.js
@@ -1,0 +1,37 @@
+import React, { useRef } from 'react';
+import { MDXProvider } from '@mdx-js/react';
+
+/**
+ * Renders its children within an MDXProvider that skips the *first*
+ * encountered H1 element. Subsequent H1 elements are rendered normally.
+ */
+const MarkdownWithoutH1 = ({ children }) => {
+  const firstH1Rendered = useRef(false);
+
+  // Reset the ref whenever the children change identity,
+  // ensuring it works correctly if the content source changes dynamically.
+  React.useEffect(() => {
+    firstH1Rendered.current = false;
+  }, [children]);
+
+  const components = {
+    h1: (props) => {
+      if (!firstH1Rendered.current) {
+        firstH1Rendered.current = true; // Mark the first H1 as "rendered" (skipped)
+        return null; // Don't render the first H1
+      }
+      // Render subsequent H1s normally
+      return <h1 {...props} />;
+    },
+    // Add overrides for other components here if needed, e.g.:
+    // p: (props) => <p style={{ color: 'blue' }} {...props} />,
+  };
+
+  return (
+    <MDXProvider components={components}>
+      {children}
+    </MDXProvider>
+  );
+};
+
+export default MarkdownWithoutH1;

--- a/gendoc.sh
+++ b/gendoc.sh
@@ -86,7 +86,7 @@ if [[ "${SKIP_GIT}" == no ]]; then
   clone_or_pull "https://github.com/openziti/ziti-sdk-c" "ziti-sdk-c" >/dev/null
   clone_or_pull "https://github.com/openziti/ziti-android-app" "ziti-android-app" >/dev/null
   clone_or_pull "https://github.com/openziti/ziti-sdk-swift" "ziti-sdk-swift" >/dev/null
-  clone_or_pull "file:///home/kbingham/Sites/netfoundry/github/ziti-tunnel-sdk-c" "ziti-tunnel-sdk-c" "docker-no-clobber-json" >/dev/null
+  clone_or_pull "https://github.com/openziti/ziti-tunnel-sdk-c" "ziti-tunnel-sdk-c" >/dev/null
   clone_or_pull "https://github.com/openziti/helm-charts" "helm-charts" >/dev/null
   clone_or_pull "https://github.com/openziti-test-kitchen/kubeztl" "kubeztl" >/dev/null
   clone_or_pull "https://github.com/openziti/desktop-edge-win" "desktop-edge-win" >/dev/null

--- a/gendoc.sh
+++ b/gendoc.sh
@@ -37,7 +37,7 @@ echo "$script_root"
 : ${SKIP_GIT:=no}
 : ${SKIP_LINKED_DOC:=no}
 : ${SKIP_CLEAN:=no}
-ZITI_DOC_GIT_LOC="${script_root}/docusaurus/_remotes"
+ZITI_DOC_GIT_LOC="${script_root}/docusaurus/docs/_remotes"
 SDK_ROOT_TARGET="${script_root}/docusaurus/static/docs/reference/developer/sdk"
 : ${ZITI_DOCUSAURUS:=yes}
 : ${SKIP_DOCUSAURUS_GEN:=no}
@@ -86,7 +86,7 @@ if [[ "${SKIP_GIT}" == no ]]; then
   clone_or_pull "https://github.com/openziti/ziti-sdk-c" "ziti-sdk-c" >/dev/null
   clone_or_pull "https://github.com/openziti/ziti-android-app" "ziti-android-app" >/dev/null
   clone_or_pull "https://github.com/openziti/ziti-sdk-swift" "ziti-sdk-swift" >/dev/null
-  clone_or_pull "https://github.com/openziti/ziti-tunnel-sdk-c" "ziti-tunnel-sdk-c" >/dev/null
+  clone_or_pull "file:///home/kbingham/Sites/netfoundry/github/ziti-tunnel-sdk-c" "ziti-tunnel-sdk-c" "docker-no-clobber-json" >/dev/null
   clone_or_pull "https://github.com/openziti/helm-charts" "helm-charts" >/dev/null
   clone_or_pull "https://github.com/openziti-test-kitchen/kubeztl" "kubeztl" >/dev/null
   clone_or_pull "https://github.com/openziti/desktop-edge-win" "desktop-edge-win" >/dev/null


### PR DESCRIPTION
…including ReMark plugins, e.g., for translating imported GitHub Markdowns' admonitions to Docusaurus admonitions