### PR TITLE
Add missing steps to "Your first service" + minor textual improvements

### DIFF
--- a/docusaurus/docs/learn/core-concepts/security/authentication/auth.md
+++ b/docusaurus/docs/learn/core-concepts/security/authentication/auth.md
@@ -3,7 +3,7 @@ title: Authentication
 ---
 
 Authentication in Ziti Edge occurs when a client wishes to interact with the Ziti Edge Controller. Authentication
-has begun when the client receives and API Session and is  complete when the API Session is fully authenticated.
+has begun when the client receives an API Session and is complete when the API Session is fully authenticated.
 API Sessions are a high level security context that represents an authenticated session with either the Ziti [edge client API](docs/reference/developer/api/01-edge-client-reference.mdx)
 or the Ziti [edge management API](docs/reference/developer/api/02-edge-management-reference.mdx).
 

--- a/docusaurus/docs/learn/core-concepts/security/authorization/policies/overview.mdx
+++ b/docusaurus/docs/learn/core-concepts/security/authorization/policies/overview.mdx
@@ -102,8 +102,8 @@ in the policy. All Ziti policies work the same way.
  order for a connection to be made. 
  
 When an identity is trying to establish an API Session to use or host a service, the Ziti
-controller will verify that they access via service policy. Once the API Session is 
-established, the controller will return a list of edge routers that the identity 
+controller will verify that it has been granted access to the service via service policy. Once the API Session is
+established, the controller will return a list of edge routers that the identity
 can use to connect to that service. The list will be all edge routers which **both**
 the identity and service have access to. It is possible that an identity may have
 access to a service and access to edge routers, but none of those edge routers

--- a/docusaurus/docs/learn/quickstarts/browzer/index.mdx
+++ b/docusaurus/docs/learn/quickstarts/browzer/index.mdx
@@ -64,7 +64,7 @@ ziti edge create ext-jwt-signer \
 
 ### Creating the Authentication Policy
 
-Authentication policies configure the network to delegate authentication one or more OIDC providers. To
+Authentication policies configure the network to delegate authentication to one or more OIDC providers. To
 create the authentication policy you only need the id of the external jwt signer (from above). Shown below is a `bash` 
 example. Replace the values accordingly. Capture the returned identity, it will be necessary after creating the external
 jwt signer:

--- a/docusaurus/docs/learn/quickstarts/services/ztha.md
+++ b/docusaurus/docs/learn/quickstarts/services/ztha.md
@@ -108,10 +108,12 @@ Here is an overview of the steps we will follow:
 5. Create a service to associate the two configs created previously into a service.
 6. Create a service-policy to authorize "HTTP Clients" to "dial" the service representing the HTTP server.
 7. Create a service-policy to authorize the "HTTP Server" to "bind" the service representing the HTTP server.
-8. Start the server-side tunneler (unless using the docker-compose quickstart) with the HTTP server identity, providing access to the 
+8. Create an edge-router-policy to grant all routers access to all identities
+9. Create a service-edge-router-policy to grant all routers access to all services
+10. Start the server-side tunneler (unless using the docker-compose quickstart) with the HTTP server identity, providing access to the 
    HTTP server.
-9. Start the client-side tunneler using the HTTP client identity.
-10. Access the HTTP server securely over the OpenZiti zero trust overlay
+11. Start the client-side tunneler using the HTTP client identity.
+12. Access the HTTP server securely over the OpenZiti zero trust overlay
 
 We can do all these steps using the OpenZiti CLI tool: `ziti`. We can also accomplish this using the OpenZiti Admin Console. We'll 
 demonstrate doing it both ways now.
@@ -170,7 +172,13 @@ ziti edge create service-policy http.policy.dial Dial --service-roles "@http.svc
 #7. Create a service-policy to authorize the "HTTP Server" to "bind" the service representing the HTTP server.
 ziti edge create service-policy http.policy.bind Bind --service-roles '@http.svc' --identity-roles "@${http_server_id}"
 
-#8. Start the server-side tunneler (unless using the docker-compose quickstart) with the HTTP server identity.
+#8. Create an edge-router-policy to grant all routers access to all identities.
+ziti edge create edge-router-policy "all-routers-all-identities" --edge-router-roles '#all' --identity-roles '#all'
+
+#9. Create a service-edge-router-policy to grant all routers access to all services.
+ziti edge create service-edge-router-policy "all-routers-all-services" --edge-router-roles '#all' --service-roles '#all'
+
+#10. Start the server-side tunneler (unless using the docker-compose quickstart) with the HTTP server identity.
 #   [optional] if you don't use an edge-router as your tunneler, you will need to download and run the tunneler for your OS
 #   if you are using a ziti-router, skip to step 9 below
 # 
@@ -182,7 +190,7 @@ ziti edge create service-policy http.policy.bind Bind --service-roles '@http.svc
 # run ziti-edge-tunnel for the client
 sudo ./ziti-edge-tunnel run -i /tmp/http.server.json
 
-#9. Start the client-side tunneler using the HTTP client identity.
+#11. Start the client-side tunneler using the HTTP client identity.
 #   This step is dependant on platform. For this demo we'll be using a virtual machine running linux and we'll be using the
 #   ziti-edge-tunnel binary. Copy the http.client.jwt from step 1 to the client machine. For the example we'll use /tmp/http.client.jwt
 #
@@ -191,7 +199,7 @@ sudo ./ziti-edge-tunnel run -i /tmp/http.server.json
 # run ziti-edge-tunnel for the client
 sudo ./ziti-edge-tunnel run -i /tmp/http.client.json
 
-#10. Access the HTTP server securely over the OpenZiti zero trust overlay
+#12. Access the HTTP server securely over the OpenZiti zero trust overlay
 curl http.ziti
 <pre>
 Hello World

--- a/docusaurus/docs/reference/ha/bootstrapping/certificates.md
+++ b/docusaurus/docs/reference/ha/bootstrapping/certificates.md
@@ -73,7 +73,7 @@ ziti pki create intermediate --pki-root ./pki --ca-name ca --intermediate-file c
 # Create the controller 1 server cert
 ziti pki create server --pki-root ./pki --ca-name ctrl1 --dns "localhost,ctrl1.ziti.example.com" --ip "127.0.0.1,::1" --server-name ctrl1 --spiffe-id 'controller/ctrl1'
 
-# Create the controller 1 server cert
+# Create the controller 1 client cert
 ziti pki create client --pki-root ./pki --ca-name ctrl1 --client-name ctrl1 --spiffe-id 'controller/ctrl1'
 
 # Create the controller 2 intermediate/signing cert


### PR DESCRIPTION
While playing around with automating a basic ziti deployment, I realized that two steps were missing in the "Your first service" page that otherwise serves as a great starting point:
The fact that services and identities need to be connected to routers via policies was neither mentioned on this page, nor on the previous ones in the quick start (unless I overlooked sth).
So my suggestion is to use the recommendation that's used in other parts of the docs: start with "allow all" policies for starters and refine later if needed.  

The PR also contains some fixes for typos/textual improvements on the side.

First time doing a PR for ziti (and not a regular contributor on GitHub), so pls let me know if there is sth. else (besides the CLA) I should take care of. 