### PR TITLE
Fix link to hosted documentation

### DIFF
--- a/docusaurus/src/pages/index.js
+++ b/docusaurus/src/pages/index.js
@@ -26,7 +26,7 @@ function HeroSection({ className }) {
                         <div className={styles.aaHeroButtons}>
                             <a href="#deploy_an_overlay"
                                className={clsx(styles.aaBtn, styles.aaBtnOutline)}>Try NetFoundry For Free</a>
-                            <a href={useBaseUrl("learn/quickstarts/network/hosted")}
+                            <a href={useBaseUrl("docs/learn/quickstarts/network/hosted")}
                                className={styles.aaBtn}>Host OpenZiti Yourself</a>
                         </div>
                     </div>


### PR DESCRIPTION
The prominent "Host OpenZiti Yourself" button currently leads to a 404 page in the documentation due to a missing "docs" path prefix.

<a href="https://openziti.io/"><img width="825" height="465" alt="image" src="https://github.com/user-attachments/assets/fdba0851-a83d-49e3-bb08-bd818f2f0eea" /></a>

:point_down: :point_down: :point_down: 

<a href="https://openziti.io/learn/quickstarts/network/hosted"><img width="850" height="448" alt="image" src="https://github.com/user-attachments/assets/0600ab6e-a315-43ed-8550-91ba1c8d7299" /></a>
