### PR TITLE
ha doc updates

### DIFF
--- a/docusaurus/docs/reference/30-configuration/controller.md
+++ b/docusaurus/docs/reference/30-configuration/controller.md
@@ -479,55 +479,64 @@ profile:
 The cluster section enables running multiple controllers in a cluster.
 
 - `commandHandler` - (optional)
-    - `maxQueueSize` - (optional, 1000) max size of the queue for processing incoming raft log
+    - `maxQueueSize` - (optional, 250) max size of the queue for processing incoming raft log
       entries
 - `commitTimeout` - (optional, 50ms) how long the leader should wait without receiving an Apply
   before sending an AppendEntry message to followers to ensure that log entries are committed in a
   reasonable time frame.
 - `dataDir` - (required) directory in which to store the bolt DB, the raft journal and snapshots
-- `electionTimeout` - (optional, 1s) how long candidates will wait without communications from the
+- `electionTimeout` - (optional, 5s) how long candidates will wait without communications from the
   leader before starting a leader election
-- `heartbeatTimeout` - (optional, 1s) How long for followers will wait without communications from
-- the leader before starting a leader election.
-- `leaderLeaseTimeout` - (optional, 500ms) How long a leader will keep leadership before stepping
+- `heartbeatTimeout` - (optional, 3s) How long followers will wait without communications from
+  the leader before starting a leader election.
+- `leaderLeaseTimeout` - (optional, 3s) How long a leader will keep leadership before stepping
   down, when it's unable to reach a quorum of nodes in the cluster
-- `logLevel` - (optional, DEBUG) The minimum level of raft log messages to emit
+- `logLevel` - (optional) The minimum level of raft log messages to emit. If unset, raft uses its
+  library default.
 - `logFile` - (optional) If not specified, raft log messages will be emitted along with all other
   ziti log messages. If specified, raft log messages will be emitted to the given log file.
-- `minClusterSize` - (optional, 1) Only used when bootstrapping the cluster. The minimum number of
-  nodes before attempting to form a raft cluster
 - `maxAppendEntries` - (optional, 64) - Maximum number of log append entries to send at any given
   time
+- `preferredLeader` - (optional, false) - If true, this node is marked as a preferred leader. A
+  non-preferred leader will automatically transfer leadership to a preferred peer when one is
+  available. Useful for steering leadership toward a specific voter, such as one co-located with
+  ops or in a chosen region.
+- `restartSelfOnSnapshot` - (optional, false) - Controls behavior after applying a raft snapshot
+  received from the leader. Applying a snapshot replaces the underlying bolt DB and requires a
+  controller restart. If true, the controller restarts itself in-process. If false, the controller
+  exits; a process manager is expected to restart it.
 - `snapshotInterval` - (optional, 2m) - How often to check to see if a new snapshot needs to be
   made. Checks will happen between `snapshotInterval` and 2 x `snapshotInterval`. This is a cluster
   wide value and should be consistent across nodes in the cluster. Otherwise the value from the most
   recently started controller will win.
-- `snapshotThreshold` - (optional, 8192) - Minimum number of new long entries before a new snapshot
+- `snapshotThreshold` - (optional, 500) - Minimum number of new log entries before a new snapshot
   will be created. This is a cluster wide value and should be consistent across nodes in the
   cluster. Otherwise the value from the most recently started controller will win.
-- `trailingLogs` - (optional, 10240) - How many logs to leave in place after a snapshot. These can
+- `trailingLogs` - (optional, 500) - How many logs to leave in place after a snapshot. These can
   be used to bring other nodes up to date that are only slightly behind, without having to send the
   full snapshot. This is a cluster wide value and should be consistent across nodes in the cluster.
   Otherwise the value from the most recently started controller will win.
 - `warnWhenLeaderlessFor` - (optional, 1m) - Emits a warning log message if a controller is part of
-   a cluster with no leader for a duration which exceeds this threshold. 
+   a cluster with no leader for a duration which exceeds this threshold. Minimum 10s.
 
 ```text
 cluster:
   commandHandler:
-    maxQueueSize: 1000
+    maxQueueSize: 250
   commitTimeout: 50ms
   dataDir: ./data
-  electionTimeout: 1s
-  heartbeatTimeout: 1s
-  leaderLeaseTimeout: 500ms
+  electionTimeout: 5s
+  heartbeatTimeout: 3s
+  leaderLeaseTimeout: 3s
   logLevel: INFO
   logFile: ./raft.log
-  minClusterSize: 3
   maxAppendEntries: 64
+  preferredLeader: false
+  restartSelfOnSnapshot: false
   snapshotInterval: 2m
-  snapshotThreshold: 8192
-  trailingLogs: 10240
+  snapshotThreshold: 500
+  trailingLogs: 500
+  warnWhenLeaderlessFor: 1m
 ```
 
 ### `trace`

--- a/docusaurus/docs/reference/30-configuration/controller.md
+++ b/docusaurus/docs/reference/30-configuration/controller.md
@@ -479,24 +479,64 @@ profile:
 The cluster section enables running multiple controllers in a cluster.
 
 - `commandHandler` - (optional)
-    - `maxQueueSize` - (optional, 250) max size of the queue for processing incoming raft log
-      entries
+    - `maxQueueSize` - (optional, 250) how many pending raft journal entries the controller will
+      buffer for processing before the adaptive rate limiter starts rejecting incoming commands.
+      The right value balances burst tolerance against responsiveness under load: a larger queue
+      absorbs more bursts without rejecting, but commands can sit in the queue long enough to go
+      stale (an update applied minutes after it was submitted may no longer reflect the operator's
+      intent), and the cluster takes longer to surface "I'm overloaded" back to the caller. A
+      smaller queue fails fast under sustained load. Watch `raft.rate_limiter.queue_size`: a queue
+      that's consistently full means either you need more buffer or your load is genuinely beyond
+      what the cluster can apply.
 - `commitTimeout` - (optional, 50ms) how long the leader should wait without receiving an Apply
   before sending an AppendEntry message to followers to ensure that log entries are committed in a
-  reasonable time frame.
+  reasonable time frame. This is the timer that bumps along pending writes on a low-activity
+  cluster: under normal write load, AppendEntries are sent continually as Apply calls happen, and
+  this timer never fires. Due to random staggering, the actual interval can extend to as much as
+  2x this value. The default keeps writes responsive without flooding followers with empty
+  heartbeats; raise it slightly to reduce per-write network chatter on a quiet cluster, or lower
+  it if you want the leader to be more aggressive about pushing out pending writes during write
+  lulls.
 - `dataDir` - (required) directory in which to store the bolt DB, the raft journal and snapshots
-- `electionTimeout` - (optional, 5s) how long candidates will wait without communications from the
-  leader before starting a leader election
-- `heartbeatTimeout` - (optional, 3s) How long followers will wait without communications from
-  the leader before starting a leader election.
-- `leaderLeaseTimeout` - (optional, 3s) How long a leader will keep leadership before stepping
-  down, when it's unable to reach a quorum of nodes in the cluster
+- `electionTimeout` - (optional, 5s) how long a candidate will spend trying to win an election
+  before giving up and starting a fresh attempt. After `heartbeatTimeout` trips and a follower
+  becomes a candidate, the candidate sends RequestVote RPCs, waits for responses, and if it hasn't
+  either won the election or seen a new leader within this window, it abandons the current attempt
+  and starts over. The default is comfortable for typical intra-region and same-continent voter
+  placements. Raise it if you see repeated election attempts failing to complete in the cluster
+  events (a sign that elections are timing out before they can finish on a high-latency or lossy
+  network); changes here are independent of changing how quickly the cluster *notices* a leader
+  is gone -- that's governed by `heartbeatTimeout`.
+- `heartbeatTimeout` - (optional, 3s) how long followers will wait without communications from
+  the leader before starting a leader election. This is the primary leaderless-detection timer:
+  a healthy cluster never trips it except briefly during a real leader transition. Tuning it
+  tunes how quickly the cluster reacts to a leader becoming unreachable. The default is
+  comfortable for typical intra-region and same-continent voter placements. Raise it if your
+  network has occasional latency spikes longer than 3s that trigger spurious elections; lower it
+  if you can guarantee tight voter-to-voter latency and want faster recovery from a real leader
+  loss. Setting it close to the actual network round-trip will cause elections to fire on normal
+  jitter.
+- `leaderLeaseTimeout` - (optional, 3s) how long a leader will keep leadership before stepping
+  down, when it's unable to reach a quorum of nodes in the cluster. This is the safety valve that
+  prevents a leader from continuing to serve writes when it's been isolated from the majority of
+  the cluster: if the leader hasn't heard back from a quorum within this window, it voluntarily
+  steps down so the majority side can elect a new leader. Tune it together with `heartbeatTimeout`
+  and `electionTimeout`; setting it longer than `electionTimeout` defeats the purpose, and setting
+  it very short makes leadership flap on transient network blips. Default works for typical
+  placements.
 - `logLevel` - (optional) The minimum level of raft log messages to emit. If unset, raft uses its
   library default.
 - `logFile` - (optional) If not specified, raft log messages will be emitted along with all other
   ziti log messages. If specified, raft log messages will be emitted to the given log file.
-- `maxAppendEntries` - (optional, 64) - Maximum number of log append entries to send at any given
-  time
+- `maxAppendEntries` - (optional, 64) maximum number of log entries the leader will pack into a
+  single AppendEntries RPC to a follower. Trades RPC efficiency against wasted work on rejection:
+  a larger batch reduces the number of RPCs needed to bring a lagging follower current, but if
+  the follower's log is divergent and rejects the batch (the leader then needs to find the
+  divergence point and resend), more data is wasted per failed attempt. The default is
+  well-balanced for typical workloads. Consider raising it if you frequently see followers
+  catching up after long disconnects on a clean network and want fewer round-trips; consider
+  lowering it if you have very tight latency targets or have observed frequent log divergence
+  during recovery.
 - `preferredLeader` - (optional, false) - If true, this node is marked as a preferred leader. A
   non-preferred leader will automatically transfer leadership to a preferred peer when one is
   available. Useful for steering leadership toward a specific voter, such as one co-located with
@@ -505,19 +545,39 @@ The cluster section enables running multiple controllers in a cluster.
   received from the leader. Applying a snapshot replaces the underlying bolt DB and requires a
   controller restart. If true, the controller restarts itself in-process. If false, the controller
   exits; a process manager is expected to restart it.
-- `snapshotInterval` - (optional, 2m) - How often to check to see if a new snapshot needs to be
-  made. Checks will happen between `snapshotInterval` and 2 x `snapshotInterval`. This is a cluster
-  wide value and should be consistent across nodes in the cluster. Otherwise the value from the most
-  recently started controller will win.
-- `snapshotThreshold` - (optional, 500) - Minimum number of new log entries before a new snapshot
-  will be created. This is a cluster wide value and should be consistent across nodes in the
-  cluster. Otherwise the value from the most recently started controller will win.
-- `trailingLogs` - (optional, 500) - How many logs to leave in place after a snapshot. These can
-  be used to bring other nodes up to date that are only slightly behind, without having to send the
-  full snapshot. This is a cluster wide value and should be consistent across nodes in the cluster.
-  Otherwise the value from the most recently started controller will win.
-- `warnWhenLeaderlessFor` - (optional, 1m) - Emits a warning log message if a controller is part of
-   a cluster with no leader for a duration which exceeds this threshold. Minimum 10s.
+- `snapshotInterval` - (optional, 2m) how often to check whether a new snapshot needs to be made.
+  Actual checks happen at a random point between `snapshotInterval` and 2 x `snapshotInterval`
+  (the jitter prevents every controller from snapshotting at the same wall-clock moment). A
+  snapshot is only created if at least `snapshotThreshold` new log entries have accumulated since
+  the last one, so `snapshotInterval` bounds how stale a snapshot can be on a busy cluster, not
+  how often snapshots actually get taken. This is a cluster-wide value and should be consistent
+  across nodes in the cluster. Otherwise the value from the most recently started controller will
+  win.
+- `snapshotThreshold` - (optional, 500) minimum number of new log entries before a new snapshot
+  will be created. Trades snapshot frequency against journal size: a lower threshold means more
+  frequent snapshots and a smaller journal on disk, but more I/O spent on snapshot creation; a
+  higher threshold means a larger journal but less snapshot churn. The default is conservative
+  and works for most clusters. Consider raising it if you have plenty of disk and want to
+  minimize snapshot I/O on a high-write cluster, or lowering it if disk is tight and you want to
+  keep the journal compact. This is a cluster-wide value and should be consistent across nodes in
+  the cluster. Otherwise the value from the most recently started controller will win.
+- `trailingLogs` - (optional, 500) how many log entries to keep in the journal after a snapshot.
+  These trailing entries let a follower that's only slightly behind catch up by replaying journal
+  entries instead of receiving a full snapshot, which is much cheaper. The right value depends on
+  how far behind your followers can fall during normal operation: too small, and any follower
+  that disconnects briefly forces a full snapshot transfer when it returns; too large, and you're
+  storing entries that will never be needed. The default works for typical disconnect patterns;
+  raise it if you have followers that occasionally disconnect for longer periods and want to
+  avoid the snapshot-transfer-and-restart dance described in [HA -> Failure Scenarios](../ha/failure-scenarios.md#lagging-or-disconnected-controllers).
+  This is a cluster-wide value and should be consistent across nodes in the cluster. Otherwise
+  the value from the most recently started controller will win.
+- `warnWhenLeaderlessFor` - (optional, 1m) emits a warning log message (`cluster running without
+  leader for longer than configured threshold`) if the controller has been part of a cluster with
+  no leader for this duration. Minimum 10s. This is the primary log-based hook for alerting on
+  leaderless clusters; lower it if you want faster alerting (down to the 10s floor), raise it if
+  your cluster regularly has short leaderless windows during normal operation and you only want
+  to be alerted on extended outages. See [HA -> Monitoring and Troubleshooting](../ha/monitoring-and-troubleshooting.md#what-to-alert-on)
+  for how to wire this into alerting.
 
 ```text
 cluster:

--- a/docusaurus/docs/reference/ha/bootstrapping/certificates.md
+++ b/docusaurus/docs/reference/ha/bootstrapping/certificates.md
@@ -94,3 +94,174 @@ ziti pki create server --pki-root ./pki --ca-name ctrl3 --dns "localhost,ctrl3.z
 # Create the controller 3 client cert
 ziti pki create client --pki-root ./pki --ca-name ctrl3 --client-name ctrl3 --spiffe-id 'controller/ctrl3'
 ```
+
+## Controller Identity Configuration
+
+Once the certificates exist on disk, the controller config's `identity:` block tells the
+controller where to find them. We recommend the four-field form: separate certs and
+separate keys for the controller's client role (used when this controller connects to
+peers) and its server role (used when peers connect to this controller).
+
+```yaml
+identity:
+  cert:        ./pki/ctrl1/certs/client.chain.pem
+  key:         ./pki/ctrl1/keys/client.key
+  server_cert: ./pki/ctrl1/certs/server.chain.pem
+  server_key:  ./pki/ctrl1/keys/server.key
+  ca:          ./pki/ctrl1/certs/ctrl1.chain.pem
+```
+
+Two things worth highlighting:
+
+* The `cert:` and `server_cert:` fields must point at the `.chain.pem` outputs from
+  `ziti pki create`, not the bare `.cert` files. The chain includes the intermediate CA
+  that peers need to validate the leaf cert back to the root.
+* `key:` and `server_key:` must each match the private key the corresponding cert was
+  issued from. The `ziti pki create server` and `ziti pki create client` commands
+  generate separate keys by default (`server.key` and `client.key` under the
+  controller's `keys/` directory), and the config above expects exactly that layout.
+
+### Simpler Variant: One Cert for Both Roles
+
+If you don't need the role separation, you can omit `server_cert` and `server_key`, in
+which case `cert` and `key` are used for both incoming and outgoing mTLS. Functionally
+this works fine -- the same cert is valid for both roles because the OpenZiti PKI tool
+doesn't restrict `ExtKeyUsage`. The four-field form above is recommended because it
+keeps the client and server key material independent, which is a healthier default for
+security-sensitive deployments and generalizes to other OpenZiti identity
+configurations (routers, SDK identities) where the separation matters more.
+
+## Common Bootstrapping Errors
+
+A few PKI-related errors come up regularly when bringing up a new HA cluster for the
+first time. Each one below lists the symptoms, the root cause, and the fix.
+
+### `tls: error decrypting message` (client cert's key doesn't match `key:` in the config)
+
+**Symptoms**
+
+One or more of:
+
+* `cluster add failed: ... remote error: tls: error decrypting message`
+* Server-side log: `tls: invalid signature by the client certificate: crypto/rsa: verification error`
+* Peer log: `x509: certificate signed by unknown authority`
+
+**Root cause**
+
+The controller config's `identity.cert` points at a client cert that was issued from a
+different private key than the one referenced in `identity.key`. During the mTLS
+handshake the controller signs the `CertificateVerify` message with `identity.key`,
+the peer verifies that signature against the public key embedded in the cert it
+received, and the signatures don't match.
+
+This usually happens when an operator uses a single `key:` field in the config (no
+separate `server_key`) and points `cert:` at a client cert that was issued with its
+own newly-generated key -- which is what `ziti pki create client` does by default.
+
+**Fix**
+
+Two options.
+
+* **Use the four-field identity form** with separate `key:` and `server_key:`, as
+  shown in [Controller Identity Configuration](#controller-identity-configuration).
+  Each field then refers to the key that actually matches its cert.
+* **Or, if you want to keep a single key**, re-issue the client cert from the
+  server's key by adding `--key-file server` to the `ziti pki create client` command:
+
+  ```bash
+  ziti pki create client --pki-root ./pki --ca-name ctrl1 \
+    --client-name ctrl1 --spiffe-id 'controller/ctrl1' \
+    --key-file server
+  ```
+
+  Both certs will then share `server.key` and a single `key:` in the config works.
+
+### `no certs presented matched the CA for this node` (cert path points at the leaf, not the chain)
+
+**Symptoms**
+
+* Peer log: `unable to validate peer connection, no certs presented matched the CA for this node`
+* Initiating side: `error dialing peer tls:other.controller:1280: ... connection refused`
+  or generic handshake failure
+* The cluster never forms, or leadership is repeatedly lost during commit
+* An `openssl s_client` handshake against the port succeeds, which can mask the issue
+  when testing
+
+**Root cause**
+
+The `ziti pki create server` and `ziti pki create client` commands each produce two
+output files: a bare leaf (`<name>.cert`) and a full chain (`<name>.chain.pem`). The
+chain file includes the intermediate CA between the leaf and the root.
+
+If `identity.cert` or `identity.server_cert` points at the bare `.cert`, the
+controller presents only the leaf during the TLS handshake. Peers don't have the
+intermediate CA in their trust store (they trust the root), so they can't build a
+valid chain and reject the connection.
+
+**Fix**
+
+Point `cert:` and `server_cert:` at the `.chain.pem` outputs, not the `.cert` files:
+
+```yaml
+identity:
+  cert:        ./pki/ctrl1/certs/client.chain.pem
+  key:         ./pki/ctrl1/keys/client.key
+  server_cert: ./pki/ctrl1/certs/server.chain.pem
+  server_key:  ./pki/ctrl1/keys/server.key
+  ca:          ./pki/ctrl1/certs/ctrl1.chain.pem
+```
+
+The recommended layout in
+[Controller Identity Configuration](#controller-identity-configuration) already uses
+chain files; this error usually comes from copying parts of older example configs
+that referenced `.cert` directly.
+
+### `x509: certificate signed by unknown authority` under systemd (relative PKI paths)
+
+**Symptoms**
+
+The cluster fails to form *only* when the controller runs under systemd; the same
+config and PKI work when the controller is launched manually from the install
+directory. Specific log lines include:
+
+* `cluster add failed: ... tls failed to verify cert: x509: certificate signed by unknown authority`
+* Admin UI / API returns `tls: first record does not look like tls`
+* Router log: `no handler for requested protocols [ziti-ctrl]`
+* Peer mesh log: `remote error: tls: internal error`
+
+**Root cause**
+
+The controller config uses **relative paths** for the PKI files (e.g.
+`pki/ctrl1/certs/server.chain.pem`). Relative paths resolve against the process's
+working directory. When the operator launches the controller by hand from the install
+directory, the working directory happens to be correct. When systemd runs the
+controller, its `WorkingDirectory=` is something else (often `/`), the relative paths
+point at files that don't exist, and the controller silently comes up without certs
+loaded. Peers then see no usable certs and respond with the trust-store error.
+
+**Fix**
+
+Two options, either is fine.
+
+* **Use absolute paths in the controller config:**
+
+  ```yaml
+  identity:
+    cert:        /etc/ziti/ctrl1/pki/ctrl1/certs/client.chain.pem
+    key:         /etc/ziti/ctrl1/pki/ctrl1/keys/client.key
+    server_cert: /etc/ziti/ctrl1/pki/ctrl1/certs/server.chain.pem
+    server_key:  /etc/ziti/ctrl1/pki/ctrl1/keys/server.key
+    ca:          /etc/ziti/ctrl1/pki/ctrl1/certs/ctrl1.chain.pem
+  ```
+
+* **Or set `WorkingDirectory=` in the systemd unit** to match the directory the
+  relative paths assume:
+
+  ```ini
+  [Service]
+  WorkingDirectory=/etc/ziti/ctrl1
+  ExecStart=/usr/local/bin/ziti controller run /etc/ziti/ctrl1/ctrl1.yml
+  ```
+
+Absolute paths are the safer default because they're robust to anything that changes
+the working directory, not just systemd.

--- a/docusaurus/docs/reference/ha/bootstrapping/configuration.md
+++ b/docusaurus/docs/reference/ha/bootstrapping/configuration.md
@@ -31,7 +31,12 @@ ctrl:
     advertiseAddress: tls:ctrl1.ziti.example.com:1280
 ```
  
-Finally, cluster-capable SDK clients use OIDC for authentication, so an OIDC endpoint must be configured.
+Finally, cluster-capable SDK clients authenticate via OIDC, so the `edge-oidc` API
+binding must be exposed on at least one web listener. As of recent controller
+versions, **if you forget to add `edge-oidc` explicitly, the controller will
+auto-bind it onto the edge-client listener and log a warning**, so a missing
+binding is no longer a hard failure. Declaring it explicitly is still recommended
+so the config matches what's actually running.
 
 ```yaml
 web:
@@ -49,3 +54,7 @@ web:
       - binding: edge-client
       - binding: edge-oidc
 ```
+
+If you want to opt out of the auto-binding (e.g., to enforce that the config is
+authoritative), set `edge.api.disableOidcAutoBinding: true` in the controller
+config.

--- a/docusaurus/docs/reference/ha/failure-scenarios.md
+++ b/docusaurus/docs/reference/ha/failure-scenarios.md
@@ -1,0 +1,312 @@
+---
+sidebar_label: Failure Scenarios
+sidebar_position: 70
+---
+
+# Failure Scenarios
+
+This page walks through what a controller cluster does when things go wrong: a node
+crashes, the network splits, the leader disappears, two nodes die at once. The goal is
+to give operators a clear picture of what still works in each case and what to do about
+it.
+
+## The Short Version
+
+In a controller cluster:
+
+* **Reads always work locally.** Every controller has the full data model, so SDK
+  clients, tunnelers and routers can keep reading services, policies and identities
+  from any reachable controller, even if it's the only one left standing. Reads from a
+  disconnected controller may be stale until it rejoins.
+* **Circuit creation works as long as any controller is reachable.** SDK clients and
+  tunnelers can ask any controller they can reach to create a circuit. However, a
+  controller can only route a circuit using routers that are connected to **it**. If
+  your routers aren't connected to every controller, losing a controller can shrink
+  the set of routers a surviving controller is able to use for new circuits. For this
+  reason, routers should generally be connected to all controllers in the cluster.
+* **Writes (model updates) need a leader and a quorum of voters.** This is the obvious
+  case: provisioning identities, changing policies, etc. It also catches an
+  easy-to-miss case: **creating a terminator is a write**, and SDK hosting
+  applications create terminators routinely as they connect or restart. So a cluster
+  that has lost write availability won't just stop accepting admin changes; SDK
+  hosting apps that come up during the outage will fail to register and won't accept
+  connections until writes work again.
+* **Existing data-plane traffic is not gated on the controller cluster.** Established
+  circuits keep flowing data through routers regardless of controller state.
+
+Most failure scenarios reduce to one of those statements.
+
+## Voter Failure Tolerance
+
+The number of voting members the cluster has determines how many can be offline and
+still accept writes. Non-voting members don't count toward this calculation.
+
+| Voting members | Quorum | Voter losses tolerated |
+| --- | --- | --- |
+| 1 | 1 | 0 |
+| 3 | 2 | 1 |
+| 5 | 3 | 2 |
+| 7 | 4 | 3 |
+
+Even-sized voter counts get no benefit over the next odd number down: a 4-voter cluster
+still tolerates 1 loss, same as 3 voters, but writes need 3 voter ACKs instead of 2.
+Stick with odd voter counts.
+
+Non-voting members can come and go freely without affecting write availability. They
+catch up via raft log replay or snapshot when they reconnect.
+
+## Single Voter Lost
+
+The common case in a 3-voter cluster.
+
+* **Writes:** still accepted. The two surviving voters form a quorum.
+* **Reads:** unaffected on every surviving controller.
+* **Leader election:** if the lost node was the leader, the surviving voters hold an
+  election. With default timeouts (`electionTimeout: 5s`, `heartbeatTimeout: 3s`) a new
+  leader is typically seated within a few seconds.
+* **Routers:** notice their preferred (lowest-latency) controller is unreachable and
+  fall back to the next-best controller for circuit creation. Terminator updates wait
+  until they can reach the new leader.
+* **Recovery:** bring the controller back up, or remove it from the cluster with
+  `ziti agent cluster remove <id>` and add a replacement.
+
+You are now running at zero spare voters. Plan to replace the lost member before the
+next failure.
+
+## Loss of Quorum
+
+This is the case the cluster sizing decision is really about. In a 3-voter cluster,
+losing two voters; in a 5-voter cluster, losing three; and so on.
+
+* **Reads:** still work locally on every surviving controller. Clients can authenticate
+  with cached data, look up services, and reach existing routers.
+* **Writes:** fully unavailable. The surviving controllers can't elect a leader and
+  can't commit anything to the journal. Update attempts return
+  `ClusterHasNoLeaderError`.
+
+:::warning
+"Writes unavailable" doesn't just mean admins can't make changes. It also blocks
+terminator creation, which happens any time an SDK hosting application connects or
+restarts. Hosting apps that come up during a quorum outage cannot register their
+terminators, and the services they offer won't be reachable until quorum is restored.
+:::
+
+This is **not** a read-only state. The cluster is fully unavailable for management
+operations. The read-only state described later in this page is a different,
+version-mismatch-driven mode.
+
+Recovery options:
+
+1. **Bring lost voters back online.** If the voter nodes are recoverable (machine
+   reboot, network issue resolved, etc.), restoring quorum lets the cluster resume
+   writes with no further action. This is the preferred recovery.
+2. **Restore the cluster from a backup.** If the lost voters are unrecoverable, there
+   is currently no in-place way to shrink the voter set without a quorum.
+   `cluster remove` requires a leader to commit the membership change, and
+   `restore-from-db` against the surviving cluster also requires a leader to dispatch
+   the snapshot through raft. Treat this as total cluster loss and rebuild from your
+   most recent backup; see [Total Cluster Loss](#total-cluster-loss).
+
+The takeaway is that quorum is a hard line. The bigger your voter count, the more
+failures it takes to cross it, but every additional voter also adds latency to every
+write. See [Topology](./topology.md) for the trade-off, and take backups frequently
+enough that the recovery-point cost of falling back to a snapshot is acceptable.
+
+## Network Partitions
+
+A partition divides the voters into a majority side and a minority side (or several
+minority sides).
+
+* **Majority side:** keeps or elects a leader; writes continue normally.
+* **Minority side:** can't elect a leader, can't accept writes. Reads still work
+  locally and may serve slightly stale data, since updates committed on the majority
+  side haven't reached it.
+* **Even split (no majority):** writes fail on both sides. This is the quorum-loss case
+  above.
+
+When the partition heals, the minority side catches up by replaying journal entries it
+missed (or applying a snapshot if it fell too far behind, see below). Split-brain isn't
+possible: raft guarantees only one leader per term, and a partition with no quorum
+can't elect one.
+
+## Leader Loss and Elections
+
+Once a leader is elected, it stays leader as long as it can reach a quorum of voters.
+The cluster does not hold elections on a schedule, and leadership does not migrate on
+its own. Leadership only changes when:
+
+* the leader becomes unreachable (process exit, network failure, host crash) and
+  followers time out waiting for heartbeats;
+* the leader voluntarily steps down because it can't reach a quorum (governed by
+  `leaderLeaseTimeout`, default 3s);
+* an operator runs `ziti agent cluster transfer-leadership`;
+* a non-preferred leader automatically transfers leadership to a preferred peer (see
+  below).
+
+When the leader becomes unreachable, the remaining voters hold an election. With
+default timeouts:
+
+* Followers wait `heartbeatTimeout` (3s) without a leader heartbeat before suspecting
+  trouble.
+* A follower then waits a randomized portion of `electionTimeout` (5s) before becoming
+  a candidate and starting an election.
+* A new leader is typically chosen within a few seconds of the old one going away.
+
+During the election, write attempts return `ClusterHasNoLeaderError`. Once a leader is
+elected, writes resume.
+
+In a heterogeneous cluster, the [`preferredLeader`](./topology.md) flag lets you steer
+leadership toward a chosen voter. After an election, a non-preferred leader will
+automatically transfer leadership to a preferred peer about 10 seconds later, so the
+cluster converges on running the leader where you want it.
+
+A consequence: if exactly one node is preferred and you manually move leadership
+elsewhere, leadership will bounce back about 10 seconds later. The feature is doing
+what you told it to do; you just can't park leadership on a non-preferred node by
+hand.
+
+If you'd rather have leadership land anywhere within a set of acceptable nodes, mark
+them all as preferred. This is usually what you want anyway, because the reason to
+prefer a leader in the first place is "this node can commit writes quickly," and any
+node close to a quorum's worth of other voters is equally good.
+
+For example, take a 3-voter cluster with two voters in one region and a third on
+another continent. The leader needs an ACK from one other voter to commit a write. If
+a same-region voter is leader, that ACK comes back at intra-region latency and writes
+are fast. If the far-away voter is leader, every commit has to wait for an ACK from
+one of the same-region voters across the continent, so writes happen at cross-
+continent latency. Marking both same-region voters as preferred keeps leadership in
+the close region without pinning it to a specific machine.
+
+You can also force a leadership change at any time:
+
+```
+ziti agent cluster transfer-leadership [target-id]
+```
+
+This is useful for planned maintenance (stop the leader after transferring leadership
+off it, so the cluster doesn't have to hold an election) or for moving leadership
+closer to the operator before a long batch of updates.
+
+## Read-Only Mode (Version Mismatch)
+
+This is a distinct mode from "lost quorum." The cluster transitions to read-only when
+voters running different software versions are present in the cluster.
+
+* **Trigger:** any peer's reported version differs from the local controller's version.
+* **Effect:** write attempts return `unable to execute command. In a readonly state:
+  different versions detected in cluster`. Reads continue normally everywhere.
+* **Recovery:** the cluster automatically exits read-only mode once all peers report
+  the same version.
+
+This mode is a safety mechanism for upgrades. It prevents a mixed-version cluster from
+committing entries that a node at the wrong version might mis-interpret. It is normal
+and expected during a rolling upgrade.
+
+Once the first upgraded node rejoins, the cluster stays read-only until every node is
+on the new version. You can't make that window shorter than the rolling upgrade itself
+takes, and the order in which you upgrade nodes doesn't change it. If you're upgrading
+the current leader, run `ziti agent cluster transfer-leadership` first so the cluster
+does a controlled handoff instead of waiting out an election timeout, but that's the
+only ordering concern.
+
+Operationally, you'll see this as the cluster being read-write, then read-only for
+the duration of the rolling upgrade, then read-write again.
+
+## Lagging or Disconnected Controllers
+
+A controller that's out of touch for a while will lag the journal. When it reconnects,
+one of two things happens:
+
+* **Short absence:** the leader streams the missed journal entries and the controller
+  catches up in place.
+* **Longer absence:** if a snapshot was created while the controller was disconnected,
+  the leader sends a snapshot to apply. Applying a snapshot replaces the underlying
+  bolt DB, which the controller cannot do under itself while serving traffic. The
+  controller terminates (or, if `cluster.restartSelfOnSnapshot: true`, restarts itself
+  in-process) about 5 seconds after applying the snapshot. A process manager is
+  expected to restart it.
+
+This is normal recovery behavior, not a failure. The controller restart that follows a
+snapshot apply is the system's way of cleanly swapping the database underneath itself.
+
+## Existing Circuits When a Controller Goes Down
+
+Circuits are owned by the controller that created them. When that controller goes
+down:
+
+* The existing circuit stays up. Routers keep forwarding traffic; there is no
+  interruption to data-plane flows.
+* The circuit cannot be re-routed. If a router on the path goes down or a better link
+  becomes available, the circuit will not adapt; it just keeps using its current path
+  until it ends naturally or fails.
+* New circuits created after the controller is gone are created by some other
+  controller and are owned by that controller for their lifetime.
+
+This is identical to the standalone-controller behavior. See the
+[Overview](./overview.md#limitations) and the
+[Routing Project Board](https://github.com/orgs/openziti/projects/13/views/1) for the
+ongoing work to make circuit management more resilient.
+
+## Router Behavior During Failures
+
+Routers connect to all controllers they know about (via their endpoints file). When a
+controller becomes unreachable:
+
+* The router uses the next-best controller by latency for new circuit creation.
+* Terminator changes (which must go through the leader) wait until the router can
+  reach the current leader. If the leader has just changed, controllers will tell the
+  router which peer is now leader.
+* When the controller cluster membership changes, the leader notifies routers and they
+  update their endpoints file. The file is read at startup and rewritten on change;
+  see [Routers](./routers.md#endpoints-file).
+
+If a router loses contact with every controller, existing circuits keep flowing
+traffic, but the router can't create new circuits or update terminators until at
+least one controller becomes reachable again.
+
+## Total Cluster Loss
+
+If every controller in the cluster is lost (e.g., destroyed underlying storage on all
+of them), you recover from a database snapshot. This requires that you've been taking
+backups: see [Operations -> Restoring from Backup](./operations.md#restoring-from-backup)
+and the [Backup guide](../../guides/deployments/10-linux/10-controller/60-backup.mdx).
+
+Either of two recovery paths gets you back. Both start the same way: bring up a fresh
+controller process with `cluster.dataDir` empty (no `raft.db`, no `snapshots/`, no
+`ctrl.db`).
+
+**Path A: `db:` setting in the controller config.** Add a `db: /path/to/backup.db`
+entry to the controller config and start the controller. It sees that it's running in
+HA mode but isn't initialized yet, reads the backup, and bootstraps a new single-node
+cluster from it. The `db:` setting is only consulted while raft has no state; once
+the cluster is initialized it's ignored on subsequent starts, so it's safe to leave
+in the config.
+
+**Path B: `ziti agent cluster restore-from-db`.** Start the controller as an
+uninitialized HA controller (no `db:` setting in the config). Then run
+`ziti agent cluster restore-from-db /path/to/backup.db` on that host. The controller
+bootstraps a new single-node cluster with itself as leader and applies the backup.
+
+After either path:
+
+1. **Grow the cluster.** Use `ziti agent cluster add` to bring up additional
+   controllers and reach the voter/non-voter layout you want.
+2. **Routers reconnect automatically.** They'll pick up the new endpoints as the
+   cluster announces them.
+
+The recovery point is the moment of the most recent snapshot. Anything committed to
+the journal after that snapshot is lost.
+
+## What to Monitor
+
+A short list of signals worth alerting on:
+
+* `warnWhenLeaderlessFor` triggers a controller log warning when no leader has been
+  seen for the configured duration (default 1m). Treat this as a quorum-health alert.
+* Cluster events (`peer.connected`, `peer.disconnected`, `leadership.gained`,
+  `state.has_leader`, `members.changed`) are emitted by the controller's event system.
+  See [Cluster Events](../50-events.mdx#cluster).
+* The `ziti agent cluster list` command shows each member's voter status, leader flag,
+  version, and connectivity. It's the fastest way to confirm cluster health from a
+  single command.

--- a/docusaurus/docs/reference/ha/failure-scenarios.md
+++ b/docusaurus/docs/reference/ha/failure-scenarios.md
@@ -351,7 +351,7 @@ happens to talk to a controller that's no longer in the cluster.
 If every controller in the cluster is lost (e.g., destroyed underlying storage on all
 of them), you recover from a database snapshot. This requires that you've been taking
 backups: see [Operations -> Restoring from Backup](./operations.md#restoring-from-backup)
-and the [Backup guide](../../guides/deployments/10-linux/10-controller/60-backup.mdx).
+and the [Backup guide](../../how-to-guides/deployments/10-linux/10-controller/60-backup.mdx).
 
 Either of two recovery paths gets you back. Both start the same way: bring up a fresh
 controller process with `cluster.dataDir` empty (no `raft.db`, no `snapshots/`, no

--- a/docusaurus/docs/reference/ha/failure-scenarios.md
+++ b/docusaurus/docs/reference/ha/failure-scenarios.md
@@ -265,6 +265,87 @@ If a router loses contact with every controller, existing circuits keep flowing
 traffic, but the router can't create new circuits or update terminators until at
 least one controller becomes reachable again.
 
+## SDK Client Behavior During Failures
+
+SDK clients keep a list of controllers and rotate between them automatically when
+the current one becomes unreachable. From the application's perspective, most
+failure scenarios are invisible: requests just take longer than usual while the
+SDK fails over, and resume normally once it finds a healthy controller.
+
+The behaviors described below are based on the Go SDK, which is the reference
+implementation. Other language SDKs (TypeScript, Swift, Java, C, etc.) follow the
+same general model but may differ in specifics -- retry policies, timeout
+defaults, refresh intervals, and pool-selection details vary. Check the
+language-specific SDK documentation when you need exact numbers; treat what
+follows as the conceptual model that all SDKs implement.
+
+### Endpoint discovery
+
+An SDK identity contains one or more initial controller endpoints, which the SDK
+uses to make first contact. After a successful authentication, the SDK can
+discover additional controller endpoints from the controller it connected to, and
+adds them to its pool of candidate endpoints.
+
+The implication: as long as at least one of the initial endpoints in the identity
+is reachable when the SDK starts, the SDK will pick up the full current cluster
+automatically. If you bring up an entirely new set of controllers without
+updating the identities, the SDKs won't know about them.
+
+### Leader change
+
+If the SDK's currently-connected controller is still reachable but loses
+leadership, the SDK sees nothing different. Model updates triggered by SDK
+actions -- the SDK's own data being updated during authentication, a terminator
+created when the SDK binds a service via a router, etc. -- are routed to the new
+leader by the controller (or router) handling them; the SDK doesn't have to know
+which controller is leader.
+
+### Controller becomes unreachable
+
+When the SDK's current controller becomes unreachable, the SDK switches to
+another endpoint from its pool. Whether the in-flight request that triggered the
+failure is transparently retried against the new controller, or returned to the
+application as an error and only the next request goes to the new controller,
+depends on the SDK implementation. Either way, the SDK doesn't stay stuck on the
+unreachable controller -- subsequent requests will be routed to a healthy one.
+
+The application sees:
+
+* **In the best case**, the SDK transparently retries and a single SDK call takes
+  longer than usual but ultimately succeeds.
+* **Otherwise**, the failed call returns an error and the application is
+  responsible for retrying. The next call goes through cleanly against a
+  different controller.
+* **If every endpoint in the pool is unreachable**, all calls fail until at least
+  one controller becomes reachable again.
+
+### Authentication continuity
+
+OIDC session tokens are JWTs, signed by the cluster's OIDC issuer and
+independently verifiable by any controller against that issuer's public key.
+They aren't stored in the raft journal -- verification is stateless and doesn't
+depend on any specific controller. When the SDK fails over to a different
+endpoint, the same token works against the new controller, and no
+re-authentication is required.
+
+This statelessness is one of the reasons OIDC is the required auth path for HA
+(see [Bootstrapping -> Configuration](./bootstrapping/configuration.md)) --
+non-JWT session tokens would have to be replicated across controllers, which
+would add latency to every auth check.
+
+### Cached state and refresh
+
+The SDK caches services, sessions, and other model data locally. Cached data
+isn't invalidated by controller failover, because the cluster shares model state
+and any controller can serve it. The SDK refreshes its API session periodically
+by polling whichever controller it's currently connected to.
+
+Pushed updates aren't part of the SDK protocol today; failover and refresh are
+both pull-based. This means the SDK doesn't learn about cluster-membership
+changes between refreshes, but it doesn't need to -- the change becomes visible
+at the next refresh, and the failover-on-error path handles cases where the SDK
+happens to talk to a controller that's no longer in the cluster.
+
 ## Total Cluster Loss
 
 If every controller in the cluster is lost (e.g., destroyed underlying storage on all

--- a/docusaurus/docs/reference/ha/migrating.md
+++ b/docusaurus/docs/reference/ha/migrating.md
@@ -34,6 +34,9 @@ Once the controller is initialized, it should start up as normal and be usable.
 The cluster can now be expanded as explained in 
 [Operations/Growing the Cluster](./operations.md#growing-the-cluster).
 
+Once the cluster is established, future binary upgrades follow the rolling-upgrade
+procedure in [Upgrading](./upgrading.md), not the standalone-upgrade pattern.
+
 ## HA to Standalone
 
 This assumes that you have a database snapshot from an HA cluster. This could either

--- a/docusaurus/docs/reference/ha/monitoring-and-troubleshooting.md
+++ b/docusaurus/docs/reference/ha/monitoring-and-troubleshooting.md
@@ -1,0 +1,504 @@
+---
+sidebar_label: Monitoring and Troubleshooting
+sidebar_position: 90
+---
+
+# Monitoring and Troubleshooting an HA Cluster
+
+This page is for operators of a running HA controller cluster: what to watch, what's
+healthy, and what to look at first when something looks wrong.
+
+Today the cluster exposes:
+
+* A primary diagnostic command (`ziti agent cluster list`) that shows membership and
+  health in one view.
+* Cluster events emitted on state transitions (leadership changes, peer connects/
+  disconnects, read-only mode entry/exit). Most cluster signals flow through here.
+* Entity change events that carry a raft index, useful for external commit-lag
+  tracking across controllers.
+* Five operator-relevant metrics: three raft rate-limiter signals and two per-peer-
+  channel heartbeat histograms.
+* A health-check HTTP endpoint that reports the local controller's leadership
+  status.
+* Log lines on every state-changing event, useful for grep-based alerting and
+  historical investigation.
+
+Cluster monitoring works as event-driven monitoring with a small metric backbone:
+you alert on cluster state transitions and a handful of key counters, and you reach
+for `cluster list` and the logs when something looks wrong.
+
+### A note on the mesh topology
+
+In current OpenZiti releases, the controller mesh is not fully connected. Only the
+leader is guaranteed to have direct connections to every follower;
+follower-to-follower connections may or may not exist. As a result, a
+`cluster list` taken from a follower will sometimes show other followers as
+`Connected: false` even when the cluster is perfectly healthy from the leader's
+perspective. The leader's view is the canonical one; follower views reflect only
+what that follower can directly see.
+
+This is expected to change in an upcoming release that moves to a fully-connected
+mesh -- after that change lands, every controller will have a direct connection to
+every other controller and the views will be consistent across nodes. Until then,
+run `cluster list` against the leader when you need an authoritative answer.
+
+Sections below walk through what healthy looks like, the diagnostic toolkit, common
+symptoms and their causes, and the minimal set of things worth alerting on.
+
+## What a Healthy Cluster Looks Like
+
+Before alerting on what's wrong, it helps to know what right looks like.
+
+### `ziti agent cluster list` on a healthy cluster
+
+Run from the leader, the command should show every member as `Connected: true`,
+exactly one node as `Leader: true`, and every node reporting the same version. For a
+3-voter cluster, that's three rows with consistent state. Voter and Preferred
+columns reflect your topology choices and shouldn't change without an operator
+action. 
+
+```
+Id      Address                              Voter  Leader  Version  Connected  Preferred
+ctrl1   tls:ctrl1.ziti.example.com:1280      true   true    v2.0.1   true       true
+ctrl2   tls:ctrl2.ziti.example.com:1280      true   false   v2.0.1   true       true
+ctrl3   tls:ctrl3.ziti.example.com:1280      true   false   v2.0.1   true       false
+```
+
+Running `cluster list` against a follower may show one or more other followers as
+`Connected: false`. That isn't a fault on its own -- in current releases the mesh
+isn't fully connected, and a follower only reports `Connected: true` for peers it
+has direct connections to. As long as the leader's view shows every voter
+connected, the cluster is healthy.
+
+### Event silence
+
+A healthy cluster is quiet on the `cluster` event namespace. Normal day-to-day
+operation produces no cluster events; the only events are `peer.connected` /
+`peer.disconnected` around legitimate restarts (planned upgrades, host reboots) and
+the corresponding `leadership.gained` / `leadership.lost` if the leader was
+involved.
+
+If you're seeing cluster events fire without a corresponding planned action,
+something's wrong.
+
+### Log noise
+
+The HA-specific log lines on a healthy cluster are limited to startup-time messages
+(`peer connected`, `raft cluster bootstrap complete`, etc.) and the occasional
+snapshot-creation message every `snapshotInterval` minutes (default: every 2
+minutes if there's been enough new log entries to cross `snapshotThreshold`).
+
+In particular, you should **not** see any of these on a healthy cluster:
+
+* `cluster running without leader for longer than configured threshold` -- triggered
+  by `warnWhenLeaderlessFor`.
+* `entering read-only mode` -- version mismatch detected.
+* `peer disconnected` outside of planned restarts.
+* `non-preferred controller gained leadership` -- fine briefly during election,
+  alarming if it sticks.
+
+### Heartbeat metrics
+
+The `peer.latency:<channel-id>` histograms should be stable within a small range --
+single-digit milliseconds for same-AZ peers, low-tens of milliseconds for
+same-region cross-AZ, low-hundreds for cross-continent. Sudden jumps in
+`peer.latency` or `peer.queue_time` are usually the first hint that something's
+wrong on the mesh.
+
+One metric exists per actual peer channel. Because the mesh isn't fully connected
+in current releases, expect the leader to have a full set of `peer.*` metrics
+(one per voter and non-voter) while followers may have fewer. This is normal;
+missing metrics on a follower correspond to peers that follower isn't directly
+connected to, not to peers that are unreachable from the cluster.
+
+Steady-state `raft.rate_limiter.queue_size` should be 0 or near-0; the
+`raft.rate_limiter.window_size` should sit close to its maximum (default 250) when
+the cluster is lightly loaded. A queue size that consistently sits above zero or a
+shrunken window means the cluster is processing close to its commit capacity.
+
+## The Diagnostic Toolkit
+
+When something looks wrong, these are the tools, roughly in the order you'd reach
+for them.
+
+### `ziti agent cluster list`
+
+First stop for any "is the cluster healthy" question. Shows every member, their
+voter status, the current leader, their reported version, whether they're currently
+connected, and the preferred-leader flag.
+
+**Run it from the leader for the canonical view.** The leader is the only node
+guaranteed to have direct connections to every other member (until the
+fully-connected mesh change lands in an upcoming release), so the leader's
+`Connected` column is the authoritative answer. A `Connected: false` entry on a
+follower's view only means that follower doesn't have a direct connection to that
+peer -- the peer may still be perfectly healthy and connected to the leader.
+
+If the membership list itself (who's a member, voter status, version) disagrees
+between controllers, that's still diagnostic: at least one controller has fallen
+behind on applying raft commands. The `Connected` column, by contrast, varies by
+mesh topology and isn't expected to agree across nodes in current releases.
+
+### Cluster events
+
+The cluster event namespace is the right alerting surface for state transitions.
+Subscribe to the `cluster` event type in the controller's event config and route to
+your observability system. The full event list is in
+[Cluster Events](../50-events.mdx#cluster); the operationally important ones are:
+
+* `state.is_leaderless` / `state.has_leader` -- leader presence transitions.
+* `state.ro` / `state.rw` -- read-only mode transitions (version mismatch).
+* `peer.disconnected` / `peer.connected` -- mesh connectivity changes.
+* `leadership.gained` / `leadership.lost` -- per-node leadership transitions, useful
+  for spotting leader churn.
+* `members.changed` -- cluster size or composition changed (someone ran
+  `cluster add`/`remove`).
+
+Each event includes the raft `index` at which it occurred, so you can correlate
+events across controllers and reconstruct timelines.
+
+### Tracking commit lag externally via entity change events
+
+Entity change events carry the raft index of the change. By default they only fire
+on the leader, but with `propagateAlways: true` in the subscription's options they
+fire on every controller as that controller applies the change. This lets an
+external collector measure per-controller commit lag without inside-the-cluster
+instrumentation.
+
+Configure the subscription on every controller you want to track:
+
+```yaml
+events:
+  commitLagTracker:
+    subscriptions:
+      - type: entityChange
+        propagateAlways: true
+    handler:
+      type: file
+      format: json
+      path: /var/log/ziti/entity-change.json
+```
+
+Then ship the JSON streams from each controller to a central collector, track the
+highest `raftIndex` you've seen from each controller (it's a field on every event),
+and compare:
+
+* `max(latest_index across controllers) - latest_index_from_controller_X` is the
+  commit lag for controller X, in raft entries.
+* `now - timestamp_of_latest_event_from_controller_X` is the lag in wall-clock
+  time, useful when comparing controllers with very different commit rates.
+
+A controller that's consistently behind in either dimension is the slow node. A
+controller that's completely silent while others are producing events is
+disconnected from the leader and isn't applying.
+
+This pattern works because each controller applies committed raft commands locally
+in its own FSM, and the entity change events fire from inside that local apply path
+-- so the events are dispatched at the moment the change becomes visible on that
+specific controller.
+
+### Health-check endpoint
+
+The `health-checks` XWeb API binding (enabled by default on HA controllers) exposes
+two endpoints:
+
+* `GET /health-checks` -- process-level health. Includes `bolt.read` (database
+  connectivity). Returns HTTP 200 when healthy.
+* `GET /health-checks/controller/raft` -- returns leadership status. Returns HTTP
+  200 with `{ "raft": { "isRaftEnabled": true, "isLeader": true } }` on the
+  leader, HTTP 429 with `isLeader: false` on followers. (The HTTP 429 follows
+  Vault's convention for "not the active node.")
+
+These are useful for liveness checks and for "which controller is currently leader"
+queries from external tooling.
+
+### Metrics
+
+Five metrics are operationally relevant for cluster monitoring:
+
+| Metric | Type | What it measures |
+| --- | --- | --- |
+| `raft.rate_limiter.queue_size` | Gauge | Number of raft commands queued for execution on this controller. Should be 0 or near-0 at rest. |
+| `raft.rate_limiter.work_timer` | Timer/Histogram | Distribution of raft command execution durations. |
+| `raft.rate_limiter.window_size` | Gauge | Current adaptive concurrency window (5-250). Shrinks under load when commands are timing out; recovers when load eases. |
+| `peer.latency:<channel-id>` | Histogram | Heartbeat round-trip time on a specific peer channel. One per peer. |
+| `peer.queue_time:<channel-id>` | Histogram | Time a message spent in the local send queue before being flushed. One per peer. |
+
+Sustained non-zero `queue_size`, a `window_size` that's repeatedly shrinking, or a
+peer-latency histogram that jumps from its baseline are all early signals that the
+cluster is approaching capacity or having mesh trouble.
+
+### Log greps
+
+When events and metrics tell you something's wrong but not what, the logs usually
+pinpoint it. Useful substrings to grep for on a controller's log:
+
+| Log substring | Meaning |
+| --- | --- |
+| `cluster running without leader for longer than configured threshold` | `warnWhenLeaderlessFor` tripped. Cluster has been leaderless past the warning duration. |
+| `entering read-only mode` | Version mismatch detected; cluster halted writes. |
+| `exiting read-only mode` | Versions reconverged; writes resuming. |
+| `peer disconnected` | A peer connection closed. Pair with `peer connected` to spot flapping. |
+| `non-preferred controller gained leadership` | Election picked a non-preferred voter. Followed by a transfer attempt ~10s later. |
+| `transferring leadership to preferred leader` | Auto-transfer to preferred peer initiated. |
+| `leadership transfer to preferred leader failed, will try next` | Auto-transfer hit a snag; will retry against another preferred peer. |
+| `no preferred leader peers are connected, retaining leadership` | Cluster couldn't find a preferred peer to transfer to; staying put. |
+| `ClusterHasNoLeaderError` | Some write attempt was rejected because no leader exists. |
+| `restored snapshot to initialized system, restart required` | This controller received a snapshot from the leader and is about to terminate for restart. |
+
+## Symptom -> Cause -> Fix
+
+Common operator-facing symptoms, what tends to cause them, and how to confirm and
+remediate.
+
+### `ClusterHasNoLeaderError` on writes
+
+**Symptom.** REST calls that mutate the model fail with `ClusterHasNoLeaderError`.
+SDK hosting apps starting up fail to register terminators with the same error.
+
+**Likely causes**, in order of probability:
+
+* The cluster is in the middle of a leader election (typically only a few seconds).
+  Wait and retry.
+* The cluster has lost quorum. `ziti agent cluster list` will show fewer than
+  `(N/2)+1` voters as `Connected: true`.
+* A network partition has cut this controller off from the majority. From this
+  controller, `cluster list` may still show all voters but their `Connected` status
+  will be wrong.
+
+**Confirm.** Run `cluster list` on this controller and on at least one other if
+reachable. Compare. Check the log for `cluster running without leader for longer
+than configured threshold`.
+
+**Fix.** If a brief election, no action needed. If quorum loss, restore enough
+voters to make quorum, then writes resume automatically. See
+[Failure Scenarios -> Loss of Quorum](./failure-scenarios.md#loss-of-quorum) for
+the recovery procedure if voters can't be recovered.
+
+### Cluster in read-only mode
+
+**Symptom.** Writes fail with `unable to execute command. In a readonly state:
+different versions detected in cluster`. Read traffic continues working everywhere.
+
+**Cause.** At least one peer is reporting a different software version from the
+others. Exact-string match on the version field; even a patch-level difference
+triggers it. See
+[Upgrading -> The Read-Only Window](./upgrading.md#the-read-only-window) for the
+full mechanics.
+
+**Confirm.** `cluster list` shows the version column for each member; the cluster
+is read-only as long as those don't all match.
+
+**Fix.** Finish the rolling upgrade so all peers are on the same version. If you
+didn't intend to be upgrading, find the node with the unexpected version (probably
+one you forgot to roll, or one that auto-upgraded from a package manager) and bring
+it back to the cluster's version.
+
+### Leadership flapping
+
+**Symptom.** `leadership.gained` and `leadership.lost` events fire repeatedly, with
+seconds-to-minutes between transitions. Writes occasionally fail with
+`ClusterHasNoLeaderError` during the gaps.
+
+**Likely causes:**
+
+* Network instability between voters -- they keep losing heartbeats and
+  re-electing. Look at `peer.latency:<channel>` histograms for spikes coinciding
+  with the events.
+* A misconfigured `preferredLeader` setup: if only one node is preferred and it's
+  unreachable but flickering, leadership will keep bouncing back to it. See
+  [Topology -> Steering Leadership](./topology.md#steering-leadership-with-preferredleader)
+  for the mark-all-close-voters-as-preferred pattern.
+* Leader getting starved out by load. Combined with elevated
+  `raft.rate_limiter.queue_size` and a shrinking `raft.rate_limiter.window_size`,
+  this points to the leader being unable to issue heartbeats fast enough.
+
+**Confirm.** Cross-reference the `leadership.*` event timestamps with peer-latency
+spikes and rate-limiter metrics.
+
+**Fix.** Address the underlying network or load issue. If the topology has only one
+preferred voter and that voter is flapping, expand the preferred set to include
+other close voters so the cluster has a stable home for leadership.
+
+### Peer connectivity flapping
+
+**Symptom.** `peer.connected` / `peer.disconnected` events for the same peer in
+close succession.
+
+**Likely causes:**
+
+* Network packet loss or instability between this pair.
+* The peer is overloaded and can't respond to heartbeats within
+  `CloseUnresponsiveTimeout` (default 30s) -- the channel is then closed
+  deliberately. Look on the *peer's* side for evidence of resource exhaustion
+  (CPU, memory, GC pauses).
+* The peer is restarting unexpectedly. Check that side's process logs.
+
+**Confirm.** The log on this side will show repeated `peer disconnected` /
+`peer connected` for the peer ID. The peer-side log usually tells you why it
+dropped (process exit, heartbeat timeout, etc.).
+
+**Fix.** Address the underlying issue on the peer side. If the network is the
+problem and can't be fixed quickly, increase
+`ctrl.options.peerHeartbeatOptions.closeUnresponsiveTimeout` so transient blips
+don't tear down the connection -- but only as a temporary workaround.
+
+### Slow writes / high commit latency
+
+**Symptom.** Model updates succeed but take noticeably longer than they used to --
+operations that previously completed in tens of milliseconds now take seconds. No
+error is returned and the cluster isn't in read-only mode; writes just feel slow.
+
+This is distinct from:
+
+* **Quorum loss**, where writes return `ClusterHasNoLeaderError`.
+* **Version-mismatch read-only mode**, where writes return `unable to execute
+  command. In a readonly state: different versions detected in cluster`.
+
+If you're getting either of those errors, jump to the corresponding entry above.
+Slow-but-successful writes have different causes.
+
+**Likely causes:**
+
+* The leader is geographically far from a quorum of voters, so every commit pays
+  cross-region round-trip latency. Verify that leadership is on a voter close to a
+  quorum's worth of other voters via `cluster list`; if it's not, the
+  `preferredLeader` auto-transfer should move it within ~10s, but a misconfigured
+  preferred set can leave it stuck on a distant voter.
+* The controller that *received* the API call isn't the leader, and the peer
+  channel between it and the leader is slow. Forwarded writes pay the peer-channel
+  round trip in addition to raft commit time. Check `peer.latency:<channel-id>` on
+  the receiving controller for the leader's channel.
+* One or more voters in the quorum are slow to ACK AppendEntries. The leader's
+  rate limiter responds by shrinking `raft.rate_limiter.window_size`. Look at
+  `peer.latency:<channel-id>` on the leader for any voter that's consistently
+  slow.
+* Apply throughput is genuinely saturated by load. `raft.rate_limiter.work_timer`
+  p99 climbing while load is high is the signal. This is rare under normal use.
+
+**Confirm.** Use the external commit-lag recipe from
+[The Diagnostic Toolkit](#tracking-commit-lag-externally-via-entity-change-events)
+to check whether one specific voter is lagging behind the others. The rate-limiter
+metrics distinguish "leader can't keep up with apply" from "one follower is slow to
+ACK." Peer-latency metrics on the receiving controller distinguish "client
+connected to a far-away controller" from "cluster itself is slow."
+
+**Fix.** Move leadership to a low-latency voter if possible. If a specific voter is
+consistently slow, investigate the host (disk, network, CPU, GC pauses). If clients
+are connecting to a controller that's far from the leader, consider whether that's
+by design -- for write-heavy clients, connecting to a controller close to the
+leader avoids the extra peer-channel hop.
+
+### Disk usage growing unexpectedly on a controller
+
+**Symptom.** A controller's `cluster.dataDir` is using significantly more disk than
+peers, or growing steadily.
+
+**Likely causes:**
+
+* The raft journal is growing because snapshots aren't being created. Check
+  `snapshotInterval`, `snapshotThreshold`, and `trailingLogs` config -- defaults
+  are 2m / 500 entries / 500 trailing.
+* The controller is falling behind on snapshot apply and journal compaction. Look
+  in the log for snapshot-creation messages; if they're absent for an extended
+  period despite write activity, something's wrong.
+
+**Confirm.** `du -sh` on `cluster.dataDir/raft.db`, `cluster.dataDir/snapshots/`
+on each controller. Significant divergence between controllers is the signal.
+
+**Fix.** Make sure `snapshotThreshold` isn't set unrealistically high. If snapshot
+creation has stopped on a specific controller, the controller's logs around the
+expected snapshot times will show why. Restarting the affected controller is a
+reasonable last resort -- it'll catch up via snapshot from the leader.
+
+### A new controller can't join the cluster
+
+**Symptom.** `ziti agent cluster add` returns an error, or the new node appears in
+the leader's `cluster list` with `Connected: false`. Check the leader's view
+specifically -- a `Connected: false` from a follower might just be the partial
+mesh that exists in current releases, not an actual join problem.
+
+**Likely causes:**
+
+* Certificate mismatch -- most commonly the new node's identity doesn't share the
+  trust domain or doesn't match the SPIFFE ID format expected by the rest of the
+  cluster. See [Bootstrapping -> Certificates](./bootstrapping/certificates.md)
+  and the [Common Bootstrapping Errors](./bootstrapping/certificates.md#common-bootstrapping-errors)
+  section.
+* Network reachability -- the new node can't reach existing controllers on the
+  advertise port, or vice versa.
+* Version mismatch -- the new node is on a different version. The cluster will
+  accept it but immediately enter read-only mode; subsequent writes will fail.
+
+**Confirm.** Check the new node's log for TLS errors (`tls: error decrypting
+message`, `x509: certificate signed by unknown authority`, `no certs presented
+matched the CA for this node`). Check existing controllers' logs for matching
+errors when the join was attempted.
+
+**Fix.** Match the symptoms to the appropriate entry in
+[Common Bootstrapping Errors](./bootstrapping/certificates.md#common-bootstrapping-errors).
+
+## What to Alert On
+
+A minimal alerting setup that covers the operationally important cases without
+producing noise:
+
+### Page-worthy (write the alert today)
+
+* **Cluster has been leaderless for too long.** Either:
+  - Grep the controller log for `cluster running without leader for longer than
+    configured threshold` and alert on its presence (this fires after
+    `warnWhenLeaderlessFor`, default 1m, configurable to as low as 10s).
+  - Or consume the `cluster` event stream and alert if a `state.is_leaderless`
+    event isn't followed by `state.has_leader` within your tolerance window.
+
+  Either signal means the cluster can't accept writes right now.
+* **Cluster entered read-only mode.** Alert on the `state.ro` cluster event. The
+  expected duration of read-only mode is the length of a rolling upgrade; an
+  unplanned occurrence (or one that lasts past your scheduled upgrade window)
+  means something needs attention.
+* **Loss of quorum.** Detectable in two ways: the leaderless alert above usually
+  catches it, and the `members.changed` event followed by a count of
+  `Connected: true` voters below `(N/2)+1` (via `cluster list` polled from the
+  leader, since the leader's view is the authoritative one) is a more direct
+  signal.
+
+### Worth alerting on but not paging
+
+* **Peer connectivity flapping.** Alert if the same peer disconnects and reconnects
+  more than a few times in a short window. A burst of `peer.disconnected` /
+  `peer.connected` events for one peer ID over (say) 10 minutes is the signal.
+* **Leadership churn.** Alert on multiple `leadership.gained` / `leadership.lost`
+  events within a short window -- leadership transitions should be rare under
+  normal operation.
+* **Sustained non-zero `raft.rate_limiter.queue_size` or a shrinking
+  `raft.rate_limiter.window_size`.** Either suggests the cluster is approaching its
+  commit-rate capacity. Not urgent, but worth investigating before it becomes
+  urgent.
+* **`peer.latency:<channel-id>` baseline shift.** A jump in the histogram median or
+  p99 from its steady state usually points at network trouble before users notice.
+
+### Worth tracking but not alerting
+
+* **External commit-lag tracker** (see
+  [The Diagnostic Toolkit](#tracking-commit-lag-externally-via-entity-change-events))
+  -- useful in dashboards and during incident investigation, but the lag values
+  themselves are noisy and rate-of-change is what matters. Set alerts based on
+  sustained lag (e.g., one controller more than N entries behind for more than M
+  minutes), not on instantaneous values.
+* **Snapshot creation rate** -- currently only visible in the logs. A controller
+  that goes too long without creating a snapshot, or one that creates them
+  suspiciously often, is worth investigating; but until snapshot metrics are
+  exposed directly, log-based detection is best.
+
+### What not to alert on
+
+* **Individual `peer.disconnected` / `peer.connected` events.** These fire on
+  planned restarts (controller upgrades, host reboots) and aren't actionable in
+  isolation.
+* **`leadership.gained` / `leadership.lost` events one at a time.** A single
+  transition is normal during planned maintenance or after a controller restart.
+  Only flap behavior is worth attention.
+* **Health-check endpoint returning 429 on a non-leader controller.** That's the
+  *correct* response on followers (Vault convention). Alert on "no controller
+  returns 200," not on "this specific controller returns 429."

--- a/docusaurus/docs/reference/ha/operations.md
+++ b/docusaurus/docs/reference/ha/operations.md
@@ -63,6 +63,32 @@ Flags:
 Use "ziti agent cluster [command] --help" for more information about a command.
 ```
 
+#### Reaching the IPC socket under systemd
+
+The OpenZiti-packaged systemd service runs the controller with `PrivateTmp=true`,
+which gives the unit its own private `/tmp` namespace. The controller writes its
+agent socket to `/tmp/gops-agent.<pid>.sock` inside that namespace, where commands
+run from outside the namespace can't see it. `ziti agent cluster ...` invoked from
+a normal shell will fail with a "could not find agent" error.
+
+The workaround is to enter the controller's mount namespace before running the
+agent command:
+
+```
+systemctl show -p MainPID --value ziti-controller.service \
+  | xargs -rIPID sudo nsenter --target PID --mount -- \
+    ziti agent cluster list
+```
+
+Replace `cluster list` with whatever agent command you need. The same pattern
+works for any other `ziti agent ...` invocation against a controller running
+under the packaged systemd unit.
+
+If you'd rather not nsenter every time, an alternative is to run the controller
+from the binary directly with a config file (no systemd), which avoids the
+namespace isolation entirely. That trades operational hygiene for convenience,
+and is generally only a good idea on development hosts.
+
 ## Growing the Cluster
 
 After at least one controller is running as part of a cluster and initialized, 

--- a/docusaurus/docs/reference/ha/operations.md
+++ b/docusaurus/docs/reference/ha/operations.md
@@ -5,6 +5,10 @@ sidebar_position: 50
 
 # Operating a Controller Cluster
 
+For rolling upgrades specifically, see [Upgrading](./upgrading.md), which covers
+the per-node procedure, the version-mismatch read-only window, snapshotting before
+upgrade, and rollback.
+
 ## Cluster Management APIs 
 
 A cluster can be managed via the REST endpoint and via the IPC agent. 

--- a/docusaurus/docs/reference/ha/operations.md
+++ b/docusaurus/docs/reference/ha/operations.md
@@ -265,6 +265,26 @@ the first controller to get the metrics message is expected to deliver the metri
 events system for external integrators. The other controllers will have `doNotPropagate` set to true,
 and will only use the metrics message internally, to update routing data.
 
+## Rate Limiting and `TooManyUpdatesError`
+
+The controller protects itself against runaway write load with an adaptive rate limiter on the
+raft command path. Under sustained heavy write activity -- large batch identity provisioning,
+terminator churn from many SDK hosting apps reconnecting at once, etc. -- incoming write requests
+can be rejected with the error `apierror.TooManyUpdatesError`. This is distinct from
+`ClusterHasNoLeaderError`: the cluster is healthy and has a leader; it's just signalling that it
+can't take on any more work right now.
+
+Clients receiving `TooManyUpdatesError` should back off and retry. The condition is transient --
+the rate limiter's adaptive window will widen again as soon as the in-flight load drops. SDKs
+typically handle this transparently. If you're writing custom code against the management API,
+exponential backoff with jitter is the right pattern.
+
+Three metrics (`raft.rate_limiter.queue_size`, `raft.rate_limiter.work_timer`,
+`raft.rate_limiter.window_size`) show the rate limiter's current state. See
+[Monitoring and Troubleshooting -> Metrics](./monitoring-and-troubleshooting.md#metrics) for what
+to watch and [the cluster config reference](../30-configuration/controller.md#cluster) for the
+tuning knob (`commandHandler.maxQueueSize`).
+
 ## Open Ports
 
 Controllers now establish connections with each other, for two purposes.

--- a/docusaurus/docs/reference/ha/operations.md
+++ b/docusaurus/docs/reference/ha/operations.md
@@ -114,8 +114,22 @@ The new node, which is not yet part of the cluster, can also be directed to reac
 out to an existing cluster node and request to be joined.
 
 ```
-user@node2$ ziti agent cluser add tls:ctrl1.ziti.example.com:1280
+user@node2$ ziti agent cluster add tls:ctrl1.ziti.example.com:1280
 ```
+
+### Voter vs Non-Voter
+
+By default, `ziti agent cluster add` adds the new node as a **voter** (`--voter=true`).
+To add a node as a non-voter -- for example, an additional controller that exists for
+regional read coverage but shouldn't participate in raft consensus -- pass
+`--voter=false`:
+
+```
+ziti agent cluster add --voter=false tls:ctrl4.ziti.example.com:1280
+```
+
+See [Topology -> Voters and Non-Voters](./topology.md#voters-and-non-voters) for
+guidance on when to add which.
 
 ## Shrinking the Cluster
 
@@ -125,20 +139,102 @@ From any node in the cluster, nodes can be removed as follows:
 user@node1$ ziti agent cluster remove ctrl2
 ```
 
+## Changing Voter Status
+
+There is no dedicated command to promote a non-voter to a voter or demote a voter to
+a non-voter. Instead, re-run `ziti agent cluster add` against the existing node with
+the desired `--voter` value:
+
+```
+# promote an existing non-voter to a voter
+ziti agent cluster add --voter=true tls:ctrl4.ziti.example.com:1280
+
+# demote an existing voter to a non-voter
+ziti agent cluster add --voter=false tls:ctrl4.ziti.example.com:1280
+```
+
+When the controller sees that a node with the same ID and address is already in the
+cluster but with the opposite voter status, it removes the existing membership and
+re-adds the node with the requested suffrage. The node itself stays running; only the
+raft configuration entry changes.
+
+If the address has changed (e.g., you've moved the node to a new host), use
+`ziti agent cluster remove <id>` first, then `cluster add` the new address with the
+desired voter status. Re-adding by address relies on the node already being reachable
+at exactly that address.
+
 ## Restoring from Backup
 
-To restore from a database snapshot, use the following CLI command:
+Two restore paths exist, and they're complementary: `restore-from-db` is the more
+versatile tool, and the `db:` config setting is a simpler way to do the same restore
+at startup when you're bringing up a fresh node.
+
+### `restore-from-db`
 
 ```
-ziti agent controller restore-from-db /path/to/backup.db
+ziti agent cluster restore-from-db /path/to/backup.db
 ```
 
-As this is an agent command, it must be run on the same machine as the controller. The path
-provided will be read by the controller process, not the CLI.
+This is an IPC agent command, so it must be run on the same host as a controller,
+and the path is interpreted by the controller process rather than the CLI. It works
+in two situations:
 
-The controller will apply the snapshot and then terminate. All controllers in the cluster will
-terminate and expect to be restarted. This is so in memory caches won't be out of sync with
-the database which has changed.
+* **Against an initialized cluster with a working leader.** The controller packages
+  the snapshot into a raft command and dispatches it through raft, so the snapshot
+  is applied on every controller in the cluster. Each controller replaces its bolt
+  DB with the snapshot's contents and then terminates so the process manager can
+  restart it cleanly -- this avoids in-memory caches drifting from the new database
+  state. Use this when you want to roll a healthy cluster back to a known good
+  model (e.g., reverting after a bad change).
+* **Against a fresh, uninitialized controller.** When the receiving controller has
+  no raft state, the command bootstraps a new single-node cluster with itself as
+  leader and applies the snapshot to that single-node cluster. Use this when you're
+  recovering from total cluster loss -- start a fresh controller, then run
+  `restore-from-db` against it to bring up a one-node cluster from the snapshot,
+  then grow the cluster with `cluster add`.
+
+What `restore-from-db` does **not** help with is a partially-alive cluster that has
+lost quorum. There's no leader to dispatch through on the existing nodes, and
+pointing the command at a fresh node wouldn't help reconstitute the broken
+cluster -- you'd just end up with a separate new cluster. For lost quorum without
+recoverable voters, see
+[Failure Scenarios -> Loss of Quorum](./failure-scenarios.md#loss-of-quorum) and
+treat it as total cluster loss.
+
+### `db:` config setting
+
+The `db:` setting was originally added to support migrating a non-HA controller into
+a cluster: in a standalone deployment, `db:` already points at the controller's
+bolt database, and adding a `cluster:` section alongside it converts the controller
+to HA without losing the existing model. The same mechanism doubles as a way to
+seed a fresh HA controller from any bolt DB snapshot.
+
+When you're standing up a fresh controller from a snapshot, you can skip the
+`restore-from-db` step by setting `db: /path/to/backup.db` in the controller
+config. On the first startup with an empty `cluster.dataDir`, the controller
+detects that it's running in HA mode but isn't initialized, reads the backup, and
+bootstraps a single-node cluster from it. The end state is identical to running
+`restore-from-db` against a fresh node.
+
+The `db:` setting is only consulted while raft has no state; on subsequent restarts
+it's ignored, so it's safe to leave in the config.
+
+Use whichever is more convenient: if you can edit the config before the first
+startup (or you're coming from a non-HA controller that already has `db:` set),
+the `db:` path is natural; if the controller is already running and you want to
+seed it from a snapshot, use `restore-from-db`. Either way, follow the
+[Total Cluster Loss](./failure-scenarios.md#total-cluster-loss) procedure for the
+full sequence (clear `dataDir`, bring up the first controller, grow the cluster,
+routers reconnect).
+
+### Which path for which situation
+
+| Situation | Use |
+| --- | --- |
+| Cluster has a leader; want to roll the data model back to a snapshot | `restore-from-db` against any cluster member |
+| Bringing up a fresh deployment from an existing snapshot | `db:` config or `restore-from-db` against a fresh node -- either works |
+| All controllers destroyed; restoring from off-host backup | Same as fresh deployment: `db:` config or `restore-from-db` against a fresh node |
+| Quorum lost on a partially-alive cluster, voters unrecoverable | Treat as total cluster loss; see [Failure Scenarios](./failure-scenarios.md#loss-of-quorum) |
 
 ## Snapshot Application and Restarts
 

--- a/docusaurus/docs/reference/ha/overview.md
+++ b/docusaurus/docs/reference/ha/overview.md
@@ -128,6 +128,11 @@ The following limitations currently apply:
    to that controller. This means that routers should generally be connected to
    all controllers.
 
+1. Downstream tools that build on OpenZiti may not yet explicitly support an HA
+   control plane. [zrok](https://zrok.io/) is one current example; see
+   [zrok#721](https://github.com/openziti/zrok/issues/721) for status. Check
+   downstream-tool release notes if you need HA at every layer of your stack.
+
 Improving routing is an ongoing focus for the OpenZiti project. 
 Issues related to routing improvments can be found on the [Routing Project Board](https://github.com/orgs/openziti/projects/13/views/1).
 

--- a/docusaurus/docs/reference/ha/overview.md
+++ b/docusaurus/docs/reference/ha/overview.md
@@ -136,6 +136,19 @@ The following limitations currently apply:
 Improving routing is an ongoing focus for the OpenZiti project. 
 Issues related to routing improvments can be found on the [Routing Project Board](https://github.com/orgs/openziti/projects/13/views/1).
 
+## Operating an HA Cluster
+
+Once a cluster is up, the day-2 documentation lives in a few places:
+
+* [Failure Scenarios](./failure-scenarios.md) -- what works (and doesn't) in
+  scenarios like single-voter loss, lost quorum, network partitions, and total
+  cluster loss; covers router and SDK client behavior during these events.
+* [Upgrading](./upgrading.md) -- rolling upgrade procedure, the version-mismatch
+  read-only window, snapshotting before upgrade, router draining, and rollback.
+* [Monitoring and Troubleshooting](./monitoring-and-troubleshooting.md) -- what to
+  watch, what a healthy cluster looks like, a symptom-driven troubleshooting
+  guide, and a tiered alerting recipe.
+
 ## Quickstart
 
 The quickstart supports running in clustered mode, see 

--- a/docusaurus/docs/reference/ha/routers.md
+++ b/docusaurus/docs/reference/ha/routers.md
@@ -87,4 +87,8 @@ want to keep an eye on controllers to make sure they can keep up with the circui
 load they receive.
 
 When managing terminators, routers will try to talk directly to the current 
-cluster leader, since updates have to go through the leader. 
+cluster leader, since updates have to go through the leader.
+
+For what a router does when its current controller becomes unreachable, the leader
+changes, or the cluster enters read-only mode, see
+[Failure Scenarios -> Router Behavior During Failures](./failure-scenarios.md#router-behavior-during-failures).

--- a/docusaurus/docs/reference/ha/topology.md
+++ b/docusaurus/docs/reference/ha/topology.md
@@ -5,78 +5,329 @@ sidebar_position: 60
 
 # Controller Topology
 
-This document discusses cluster size and member placement.
+This document is about how to size and place the controllers in an HA cluster. The
+decisions break down into four:
 
-## Number of Controllers
+* **How many voters** the cluster has -- sets failure tolerance and write latency.
+* **How many non-voters** the cluster has -- scales reads and regional coverage
+  without affecting write availability.
+* **Where the controllers run** -- geographic placement determines how fast a write
+  commits.
+* **Which voters are acceptable leaders** -- controlled by the `preferredLeader`
+  flag, lets you steer leadership toward a low-latency quorum.
 
-### Management
+One question that comes up often is whether to put a load balancer in front of the
+cluster. The short version: don't. Routers and the enrollment flow won't work
+through an LB at all, and SDK clients don't need it. There's a section below that
+walks through why, with the nuances.
 
-The first consideration is how many controllers the network should be able to lose without losing
-functionality. A cluster of size N needs (N/2) + 1 voting members connected to be able
-to take model updates, such as provisioning identities, adding/changes services and updating policies.
+The rest of this page walks through each decision, with worked examples at the end.
 
-Since a two node cluster will lose some functionality if either node becomes unavailable, a minimum
-of 3 nodes is recommended.
+## Picking a Cluster Size: 3 vs 5 vs 7 Voters
 
-### Clients
+Voters are the controllers that participate in raft consensus. Every model update
+needs an ACK from a majority of voters before it commits, so the voter count drives
+both how many voter losses the cluster tolerates and how fast writes are.
 
-The functionality that controllers provide to clients doesn't require any specific number of controllers.
-A network manager will want to scale the number controllers based on client demand and may want to 
-place additional controllers geographically close to clients for better performance.
+| Voters | Quorum | Voter losses tolerated | Voters that must ACK each write |
+| --- | --- | --- | --- |
+| 1 | 1 | 0 | 1 (just the leader) |
+| 3 | 2 | 1 | 2 |
+| 5 | 3 | 2 | 3 |
+| 7 | 4 | 3 | 4 |
 
-## Voting vs Non-Voting Members
+**3 voters** is the smallest cluster that actually buys you HA. It survives one
+voter loss and only needs one extra ACK per write. This is the right starting point
+for almost everyone.
 
-Because every model update must be approved by a quorum of voting members, adding a large number of voting
-members can add a lot of latency to model changes. A three node cluster in the same data center would 
-likely need a few 10s of milliseconds. A cluster with a quorum on a single continent might take a hundred
-milliseconds, and one that had to traverse large portions of the globe might take half a second.
+**5 voters** survives two simultaneous voter losses. Pick this when the cost of an
+outage is high enough that "one node down for maintenance + one node fails" needs to
+still keep writes flowing, or when you're spreading voters across enough regions
+that you expect occasional partitions to take a voter off the majority side.
 
-If the network has enough voting members to meet availability needs, then additional controllers added
-for performance reasons should be added as non-voting members.
+**7 voters** survives three. Rarely worth it. Every additional voter adds latency
+to every write because the leader has to wait for one more ACK to reach quorum, and
+the failure tolerance you're buying is increasingly unlikely to be the failure mode
+that actually hits you.
 
-Additionally, having a quorum of controllers be geographically close will reduce latency without necessarily
-reducing availability.
+**Use odd voter counts.** The code doesn't enforce it, but even-sized voter
+clusters are strictly worse than the next odd number down. A 4-voter cluster
+tolerates only 1 loss (same as 3), but writes need 3 ACKs instead of 2. A 6-voter
+cluster tolerates 2 (same as 5) and needs 4 ACKs. Stick to 3, 5, or 7.
 
-### Example
+If you need more controllers than your chosen voter count -- for read scale,
+regional coverage, or both -- add them as non-voters. That's the next section.
+
+## Voters and Non-Voters
+
+A cluster has two kinds of members.
+
+**Voters** participate in raft consensus. They vote in leader elections, can be
+elected leader, and every write needs an ACK from a majority of them before it
+commits.
+
+**Non-voters** receive the journal but don't vote and can't be elected leader. They
+hold the full data model and serve reads exactly like voters do.
+
+All non-leader controllers -- voter followers and non-voters alike -- handle writes
+the same way: a client request is forwarded to the current leader, the leader
+commits the write through raft, and the result comes back through the controller
+the client connected to. So from a client's perspective there is no functional
+difference between connecting to a voter follower and connecting to a non-voter.
+The voter/non-voter distinction only matters for raft itself: whether the node's
+vote counts toward quorum, and whether it's eligible to be elected leader.
+
+### When to Add Non-Voters Instead of More Voters
+
+Once your voter count meets your failure-tolerance needs, additional controllers
+should be non-voters. Two reasons:
+
+1. **Writes get slower with every voter.** The leader has to collect ACKs from a
+   majority before committing. More voters means a larger majority, and if voters
+   are geographically spread, the leader has to wait for the slowest member of that
+   majority every time.
+2. **Non-voters cost nothing on writes.** They get the journal asynchronously and
+   never block a commit. You can add as many as you want without slowing writes
+   down.
+
+So the pattern is: pick a voter count for failure tolerance (3, 5, or 7), then add
+non-voters wherever you need more local read capacity or regional coverage.
+
+## Geographic Placement
+
+The leader has to wait for ACKs from a quorum of voters before every write commits.
+That ACK round trip is real network time. If your voters are spread across
+continents, every write pays the cost of reaching the slowest voter in the quorum.
+
+Some ballpark numbers:
+
+| Voter spread | Round-trip ACK to a single voter |
+| --- | --- |
+| Same data center | ~1 ms |
+| Same region, different AZ | ~5-10 ms |
+| Same continent | ~30-80 ms |
+| Cross-continent | ~150-300 ms |
+
+Those are per-write, and they add up fast when you're provisioning identities or
+doing batch policy changes.
+
+### Keep a Quorum Close
+
+The trick is to put a *quorum's worth* of voters geographically close together, so
+a write can commit on local-region latency. Voters beyond that quorum can be
+anywhere -- they receive the journal but don't block commits.
+
+In a 3-voter cluster, the quorum is 2. So put two voters in the same region
+(ideally different availability zones so an AZ failure doesn't take both) and put
+the third voter somewhere else. As long as the leader is one of the two close
+voters, writes commit on intra-region latency. If the leader is the distant voter,
+every write pays cross-region latency. That's where
+[`preferredLeader`](#steering-leadership-with-preferredleader) comes in -- covered
+in the next section.
+
+In a 5-voter cluster, the quorum is 3. Put three voters in the same region, with
+the remaining two anywhere. Same principle.
+
+### Spread Non-Voters Wherever Clients Are
+
+Non-voters don't enter into the write-latency calculation at all, so you can put
+them wherever your clients are. Each region with significant client population gets
+its own non-voter (or non-voters) so that SDK clients have a low-latency controller
+to talk to for reads, authentication, and circuit creation.
+
+A region with a non-voter doesn't need a voter, and a region with a voter doesn't
+need a non-voter -- the same controller does both jobs for the clients in that
+region. The only reason to add non-voters in a voter region is to handle more
+client load than a single controller can serve.
+
+## Steering Leadership with `preferredLeader`
+
+Geographic placement only helps if the leader happens to be in the close-together
+region. If raft picks the distant voter as leader (which it can, since any voter is
+eligible by default), every write pays cross-region latency until leadership
+changes.
+
+`preferredLeader` is the knob that fixes this. Mark a voter as preferred by setting
+the following in its controller config:
+
+```yaml
+cluster:
+  preferredLeader: true
+```
+
+When the cluster has at least one preferred voter and a non-preferred voter is
+elected leader, the cluster automatically transfers leadership to a preferred peer
+about 10 seconds after the election. The end state is that leadership lives on a
+preferred voter whenever one is available.
+
+### Mark the Whole Close Quorum, Not Just One Node
+
+The natural inclination is to pick one specific voter and make it preferred. Don't.
+If exactly one node is preferred and that node goes down, leadership will move to a
+non-preferred voter (correctly -- the cluster needs *some* leader). When the
+preferred node comes back, leadership will bounce to it again. That's two
+unnecessary leader transitions for what could have been zero.
+
+Mark every voter in your close-together region as preferred instead. Leadership
+will land on whichever one is up, and you won't get bounce-back churn on recovery.
+
+Take the 3-voter cluster from the previous section: two voters in region A, one
+voter in region B. Mark both region-A voters as preferred. Leadership stays in
+region A as long as either of them is up. Writes always commit on intra-region
+latency unless both region-A voters are simultaneously down.
+
+### Manual Transfers Still Work, but Bounce Back
+
+If you run `ziti agent cluster transfer-leadership` to move leadership manually, the
+auto-transfer logic still applies. If the target you picked isn't preferred (and a
+preferred peer is up), leadership will bounce back about 10 seconds later. To park
+leadership on a specific non-preferred node deliberately, you'd have to disable the
+preferred flag on the others, which is more trouble than it's worth in normal
+operation. See [Failure Scenarios -> Leader Loss and
+Elections](./failure-scenarios.md#leader-loss-and-elections) for the full mechanics.
+
+## Don't Front Controllers with a Load Balancer
+
+The cluster handles its own endpoint distribution and client failover, so it
+doesn't need an external load balancer. More importantly, putting one in the path
+breaks several things that depend on direct controller connectivity.
+
+### What Won't Work
+
+**Enrollment.** Enrollment JWTs are signed with each controller's server cert/key
+pair. A TLS-terminating load balancer presents its own certificate to clients,
+which breaks both the mTLS handshake and the JWT signature validation the SDK does
+on receipt. This is the most common way operators get burned by a load balancer in
+front of a cluster.
+
+**Router-to-controller traffic.** Routers maintain persistent mTLS connections to
+the controllers in their endpoints list. They use those connections for the
+data-model snapshot stream, cluster membership updates, terminator changes, and
+circuit creation messaging. None of that survives an LB hop, whether the LB
+terminates TLS or passes it through; the control-plane protocol isn't HTTP.
+
+**Controller-to-controller mesh.** The raft journal and command-forwarding traffic
+between controllers is similarly direct, persistent, mTLS-authenticated, and not a
+fit for any kind of LB.
+
+### What Could Work but Doesn't Help
+
+Post-enrollment SDK traffic to the edge client API would technically function
+through a TLS pass-through LB (mTLS is preserved, the request is plain HTTPS, and
+session tokens work cluster-wide because they're stored in raft). But SDK clients
+don't need it:
+
+* Every controller serves `GET /edge/client/v1/controllers`, which returns the live
+  list of cluster members with their real addresses.
+* SDK clients use that list to talk directly to controllers and fail over among
+  them when one is unreachable.
+
+So an LB in front of the edge client API adds a hop, an extra failure domain, and
+a layer of state that has to be kept in sync with cluster membership, all for zero
+functional gain. The cluster's own discovery mechanism is doing the same job
+better.
+
+### What to Do Instead
+
+If you want a single DNS name that points clients at the cluster, use plain DNS --
+round-robin records or a health-checked DNS resolver are both fine, because they
+don't sit in the path of the actual connection. They give clients an initial
+address to hit; from there, the cluster takes over via
+`/edge/client/v1/controllers` and the router endpoints file.
+
+## Worked Examples
+
+### Single Region, Three Voters
+
+Simplest production-ready layout. Three voters in the same region, in different
+availability zones so an AZ failure doesn't take the cluster down.
+
+* One in us-east-1a (voting)
+* One in us-east-1b (voting)
+* One in us-east-1c (voting)
+
+No `preferredLeader` flags needed: every voter is equally acceptable as leader, so
+there's nothing to steer leadership toward or away from. Writes commit at intra-AZ
+latency. Tolerates one AZ failure.
+
+If clients are concentrated in us-east, no non-voters are needed. If clients also
+exist in other regions, add non-voters near them -- see the next example.
+
+### Multi-Region, Six Nodes
 
 **Requirements**
 
-1. The network should be able to withstand the loss of one voting member.
-1. Controllers should exist in the US, EU and Asia, with two in each region. 
+1. The network should withstand the loss of one voting member.
+2. Controllers should exist in the US, EU and Asia, with two in each region.
 
-To be able to lose one voting member, we need three voting nodes, with six nodes total.
+Three voters, six nodes total, with two voters in one region and the third in
+another for partition resilience.
 
-We should place 2 voting members in the same region, but in different availability zones/data centers.
-The third voting member should be in a different region. The rest of the controllers should be non-voting.
-
-**Proposed Layout**
-
-So, using AWS regions, the network might have:
-
-* One in us-east-1 (voting)
-* One in us-west-2 (voting)
+* One in us-east-1 (voting, preferred)
+* One in us-west-2 (voting, preferred)
 * One in eu-west-3 (voting)
 * One in eu-south-1 (non-voting)
 * One in ap-southeast-4 (non-voting)
 * One in ap-south-2 (non-voting)
 
-Assuming the leader is one of us-east-1 or us-west-2, model updates will only need to be accepted by 
-one relatively close node before being accepted. All other controllers will recieve the updates as well,
-but updates won't be gated on communications with all of them.
+The two US voters are marked preferred, so leadership stays in the US whenever a
+US voter is up. Writes only need an ACK from one other voter to reach quorum; with
+the leader in us-east-1 or us-west-2, the close pairing keeps commits on
+intra-continent latency. The EU voter is there to keep quorum reachable if the
+entire US region partitions away. Clients in EU and Asia connect to local
+non-voters for low-latency reads.
 
-**Alternate**
+### Multi-Region, Tighter Quorum
 
-For even faster updates at the cost of an extra controller, two controllers could be in the US Eastern DC: one in us-east-1
-and one in us-east-2. The third member could be in the EU. Updates would now only need to be approved by two 
-very close controllers. If one of them went down, updates would slow down, since updates would need to be done
-over longer latencies, but they would still work.
+Same shape as the previous example, but pays for one extra controller to put the
+two US voters in the same metro area. us-east-1 and us-east-2 are both voters now
+(a few milliseconds apart); us-west-2 stays in the deployment but drops to
+non-voting. Total node count goes from 6 to 7.
 
-* One in us-east-1 (voting)
-* One in us-east-2 (voting)
+* One in us-east-1 (voting, preferred)
+* One in us-east-2 (voting, preferred)
 * One in us-west-2 (non-voting)
 * One in eu-west-3 (voting)
 * One in eu-south-1 (non-voting)
 * One in ap-southeast-4 (non-voting)
 * One in ap-south-2 (non-voting)
 
+Writes only need an ACK from us-east-1 or us-east-2 (whichever isn't leader) and
+complete in single-digit milliseconds. If one of the East voters goes down, writes
+still work but slow to cross-continent latency (the leader has to wait for an ACK
+from eu-west-3) until the missing East voter comes back. If both US voters go
+down, the cluster loses quorum: eu-west-3 is the only surviving voter, and
+non-voters don't count toward quorum no matter how many of them are reachable.
+Recovery in that case is either to bring a US voter back or to treat it as total
+cluster loss; see [Failure Scenarios](./failure-scenarios.md#loss-of-quorum).
 
+### Single Region, Five Voters
+
+Use this when you want intra-region write latency in the common case *and* the
+ability to survive simultaneous voter losses. The classic case is a network where
+a controller might be down for maintenance and another voter fails at the same
+time -- a 3-voter cluster loses quorum in that scenario; a 5-voter cluster keeps
+writing.
+
+* One in us-east-1a (voting, preferred)
+* One in us-east-1b (voting, preferred)
+* One in us-east-1c (voting, preferred)
+* One in us-west-2 (voting)
+* One in eu-west-3 (voting)
+
+Quorum is 3. With three voters in us-east-1 across AZs, leadership stays on a
+preferred voter, and the quorum forms entirely within us-east-1. Writes commit at
+intra-region latency in the common case.
+
+Failure tolerance is the point of the extra voters. If two of the us-east-1 AZs
+go down at once -- rare but real, especially during a regional incident -- you
+still have one us-east-1 voter plus us-west-2 plus eu-west-3 (3 voters total =
+quorum), so writes keep working. They'll slow to cross-region latency until the
+missing us-east-1 voters come back, since the leader now has to wait for an ACK
+from a distant voter, but the cluster stays available.
+
+If the entire us-east-1 region drops off, you're left with us-west-2 and eu-west-3
+(2 voters), which is below quorum. For full single-region-outage survival, you'd
+want a 2+2+1 layout across three regions instead, at the cost of every write
+paying cross-region latency in the common case. That trade is rarely worth it,
+but if you need it, it's there.

--- a/docusaurus/docs/reference/ha/upgrading.md
+++ b/docusaurus/docs/reference/ha/upgrading.md
@@ -1,0 +1,383 @@
+---
+sidebar_label: Upgrading
+sidebar_position: 75
+---
+
+# Upgrading an HA Controller Cluster
+
+Upgrading a running HA cluster is a node-by-node rolling operation. There's no special
+cluster-wide procedure; you bring each controller down, replace its binary, and bring
+it back up, then move to the next one. Routers and SDK clients stay connected
+throughout, falling over to other controllers as nodes cycle.
+
+The one thing that's different from upgrading a standalone controller is that the
+cluster will be in
+[version-mismatch read-only mode](./failure-scenarios.md#read-only-mode-version-mismatch)
+for the duration of the rolling upgrade. Reads continue to work; writes (model
+updates, terminator creation) are blocked until every node is on the new version. The
+window is bounded by how long the upgrade takes overall, not by which node you
+upgrade first.
+
+At a glance:
+
+1. Take a database snapshot from a controller.
+2. Pick a node. If it's the leader, run `transfer-leadership` first.
+3. Stop the controller, replace its binary, start it again.
+4. Wait for the cluster to recognize it as healthy.
+5. Repeat for each remaining node.
+
+The rest of this page walks through each step, then covers routers and SDK clients,
+the Helm chart, and what to do if the upgrade goes wrong.
+
+## Before You Upgrade: Snapshot the Cluster
+
+Take a database snapshot before any controller binary upgrade. The controller will
+apply schema migrations on startup the first time the new binary runs, and that
+schema change is one-way. If the upgrade goes badly, the only way back to the
+previous version is to restore from a snapshot taken before the migration ran.
+
+The snapshot is always created on the controller you're talking to, using whichever
+of its peers' state that controller currently has. **Take the snapshot from the
+cluster leader** so the snapshot is as up-to-date as possible. Identify the leader
+with `ziti agent cluster list` (or `ziti ops cluster list` over REST).
+
+There are two equivalent ways to trigger the snapshot.
+
+**Via the IPC agent**, on the same host as the leader controller:
+
+```
+ziti agent controller snapshot-db /var/lib/ziti/controller/backups/pre-upgrade.db
+```
+
+**Via the management REST API**, from anywhere the `ziti` CLI is logged in against
+the leader:
+
+```
+ziti fabric db snapshot /var/lib/ziti/controller/backups/pre-upgrade.db
+```
+
+Either way:
+
+* The path argument is interpreted by the controller process, not the CLI, so the
+  directory must be writable from the controller's perspective. (For REST, the CLI
+  just passes the path through; nothing is written on the client.)
+* The output is a bolt DB snapshot in the format the
+  [Total Cluster Loss](./failure-scenarios.md#total-cluster-loss) recovery paths
+  consume.
+* You only need one snapshot per upgrade -- the cluster's model is consistent across
+  all controllers, so snapshotting more than one node is redundant.
+
+Keep both the snapshot and the previous controller binary somewhere safe until
+you've confirmed the upgrade is working. They're the two ingredients of a rollback.
+
+## The Procedure: Rolling Upgrade
+
+Once you have a snapshot, upgrade controllers one at a time. Pick whichever node you
+want to upgrade first; the order doesn't change the read-only window or the end
+result. A small step that's worth taking for the current leader is to move
+leadership off it before stopping it, so the cluster does a controlled handoff
+instead of waiting for an election to fire.
+
+Per node:
+
+1. **If this is the leader, transfer leadership off it.**
+
+   ```
+   ziti agent cluster transfer-leadership
+   ```
+
+   Without a target argument, the cluster picks an eligible voter (preferring any
+   node marked `preferredLeader: true`). You don't strictly have to do this -- if
+   you just stop the leader, the surviving voters will elect a new one in a few
+   seconds -- but a clean transfer avoids the short `ClusterHasNoLeaderError`
+   window during the election.
+
+2. **Stop the controller.**
+
+   With systemd, `systemctl stop ziti-controller`. Otherwise, send the process a
+   `SIGTERM` and wait for it to exit cleanly.
+
+3. **Replace the binary.**
+
+   Install the new version of `ziti` (or the controller-specific package, depending
+   on how you deploy). The on-disk state in `cluster.dataDir` and the PKI directory
+   don't change.
+
+4. **Start the controller.**
+
+   `systemctl start ziti-controller` or your equivalent. On startup the new binary
+   will detect any pending schema migration and apply it before opening listeners.
+
+5. **Confirm the node has rejoined the cluster.**
+
+   From any controller, `ziti agent cluster list` should show the upgraded node as
+   `Connected: true` and reporting the new version. Wait until you see that before
+   moving to the next node -- it confirms the node is back in the mesh and has
+   caught up on any journal entries it missed during the restart.
+
+Repeat for each remaining controller. When the last node finishes its upgrade and
+reports the new version, the cluster automatically exits read-only mode and writes
+work again.
+
+### Don't Worry About Order
+
+Two notes about ordering that come up:
+
+* **It doesn't matter whether you upgrade the leader first or last.** The read-only
+  mode kicks in as soon as any peer is at a different version, and clears only when
+  all peers match. The total read-only window is the duration of the rolling
+  upgrade, not the duration after the leader is touched.
+* **It doesn't matter which non-leader node you do first.** Pick the most
+  convenient.
+
+The leadership-transfer step in (1) is purely about avoiding a brief leaderless
+window, not about ordering correctness.
+
+## The Read-Only Window
+
+The cluster enters read-only mode the moment any peer reports a different version
+from the local controller's, and stays there until every peer reports the same
+version. During this window:
+
+* **Reads work normally on every controller.** Clients can authenticate, look up
+  services, and create circuits.
+* **Writes return an error.** Specifically, write attempts get `unable to execute
+  command. In a readonly state: different versions detected in cluster`. This
+  includes the easy-to-miss case: terminator creation, which fires whenever an SDK
+  hosting application connects or restarts. Hosting apps that come up during the
+  window will fail to register; their services won't be reachable until you finish
+  the upgrade.
+
+Some details that surprise people:
+
+### Exact version-string match
+
+The version comparison is exact-string equality on the build-time version, not
+semver-aware. `v1.6.5` and `v1.6.6` mismatch. `v2.0.0` and `v2.0.1` mismatch.
+`v2.0.1` and `v2.0.1-rc1` mismatch. Dev builds (`v0.0.0`) only match other dev
+builds.
+
+This means any rolling upgrade triggers the read-only window, including a patch
+release. There's no "safe within a patch series" carve-out.
+
+### Plan SDK hosting work around the window
+
+The single most disruptive effect of the window is on SDK hosting apps that need to
+register terminators during the upgrade. If you have hosting apps that restart
+frequently or that depend on terminator registration succeeding within a few seconds
+of startup, schedule the rolling upgrade for a window where you can tolerate failed
+registrations, or stage the hosting-app restarts to before or after.
+
+Existing terminators stay in place across the upgrade; the read-only mode only
+blocks *new* writes, not previously-committed ones. So already-running hosting apps
+with terminators in place keep serving connections fine.
+
+### The window can't be shortened by order
+
+As covered in the previous section: which node you upgrade first doesn't change the
+total read-only duration. The window starts when the first upgraded peer joins and
+ends when the last unupgraded peer is replaced. The only way to make it shorter is
+to make the rolling upgrade itself faster.
+
+## Routers and SDK Clients
+
+Routers and SDK clients have no hard version gate with controllers. An older router
+can connect to a newer controller and vice versa; the connection succeeds and
+features that the older side doesn't understand simply aren't used. The same is
+true for SDK clients. So you can upgrade controllers without coordinating router or
+SDK versions, and you can upgrade routers without first upgrading controllers.
+
+### SDK compatibility is the strongest contract
+
+Of the three components, the SDK has the strongest backward-compatibility
+commitment. Once an SDK is shipped into client applications, it can be effectively
+impossible to upgrade (mobile apps, embedded devices, third-party integrations), so
+the project treats SDK API breakage as a serious bug. You should generally be able
+to upgrade controllers and routers without touching the SDK side at all.
+
+### Routers and controllers: keep the skew small
+
+Router-controller compatibility is shimmed, not gated. An older router talking to a
+newer controller (or vice versa) connects fine and falls back to whatever feature
+set both sides understand. A small version gap during a rolling upgrade is normal
+and expected.
+
+A larger skew is best avoided. Bugs that only show up when the router and
+controller are far apart in version do creep in occasionally, and the
+regression-test coverage is naturally weaker for distant version pairs. Keep router
+upgrades within a release or two of the controller version you're running, and
+avoid leaving multi-major-version gaps in place for long.
+
+### Router upgrade procedure
+
+Routers upgrade independently. Stop the router, replace the binary, start it.
+Established circuits flowing through the router will be torn down on restart and
+re-created against the surviving routers; that's the same behavior as a router
+restart for any other reason. There's no cluster-wide coordination needed.
+
+If you have many routers and want to minimize circuit churn, upgrade them one at a
+time so most of the data plane is always available, and let SDK clients fail over
+to other paths as each router cycles.
+
+### Draining a hosting router before upgrade
+
+If the router you're upgrading is hosting terminators for services, you can drain
+it before the restart so existing traffic finishes cleanly while new traffic
+prefers other paths. On the host running the router:
+
+```
+ziti agent router quiesce
+```
+
+This marks every terminator on this router as failed in the controller's data
+model. The terminator records aren't deleted; they're flagged so that the
+controller stops picking them for new circuit creation as long as some other
+healthy terminator for the service exists. Existing circuits keep flowing.
+
+Once new traffic has moved off, stop and upgrade the router. If you change your
+mind before the restart, the operation is reversible with `ziti agent router
+dequiesce`.
+
+**After the upgrade, run `dequiesce` on the restarted router.** SDK-hosted
+terminators heal automatically when the hosting application reconnects, because the
+SDK creates fresh terminators on connect. Most other terminators need an explicit
+dequiesce:
+
+* **Manually created terminators** (created via the REST API and bound to a
+  specific router) aren't recreated on restart, so without dequiesce they stay in
+  the failed state and the service stays unreachable through that router.
+* **Edge-router-tunneler terminators** are also generally left in place rather than
+  recreated. The router caches terminator IDs so that on reconnect it can tell the
+  controller "these terminators are still good" instead of re-registering them --
+  which is great for normal restarts, but it also means a quiesced terminator stays
+  quiesced through the restart and needs an explicit dequiesce afterward.
+
+Running dequiesce post-upgrade is safe in all cases. If every terminator on the
+router has already healed on its own, dequiesce is a no-op.
+
+Future versions of OpenZiti will likely extend quiesce to also raise the router's
+routing cost to its maximum, so the router stops being used for transit traffic as
+well as for terminator hosting; dequiesce will then drop the cost back to its
+previous value. The drain pattern shown here is forward-compatible with that change
+-- you'll get a broader drain "for free" when the feature lands.
+
+Quiesce only helps if there's another router available to host the same service. A
+single hosting router has nowhere to drain to, so quiesce on it will just stop new
+connections from being accepted until the upgrade finishes and the terminators come
+back.
+
+## Helm Chart Upgrades
+
+The official OpenZiti Helm chart (`openziti/helm-charts/charts/ziti-controller`)
+deploys an HA cluster as **one Helm release per controller node**, not one release
+with multiple replicas. Each release is a single-replica Deployment with
+`strategy: Recreate`, backed by a per-release PVC for `cluster.dataDir`. There is
+no orchestration in the chart that ties the releases together for upgrade
+purposes -- `helm upgrade` against one release cycles exactly one pod and waits for
+it to come back. Cross-release coordination is the operator's job.
+
+A few specific things that matter when upgrading a Helm-deployed cluster.
+
+### Snapshot first; the chart doesn't do it for you
+
+The chart has no `pre-upgrade` hook that takes a database snapshot. You have to do
+it yourself before running `helm upgrade`. From a shell with `kubectl` access:
+
+```
+kubectl exec -n <namespace> <leader-pod> -- \
+  ziti agent controller snapshot-db /persistent/pre-upgrade.db
+```
+
+The snapshot lands on the controller's PVC inside the pod. Copy it out
+(`kubectl cp`) and keep it alongside the previous chart version somewhere you can
+get to without the cluster.
+
+### Roll through releases one at a time
+
+Upgrade each Helm release sequentially, waiting between them:
+
+```
+helm upgrade ziti-controller1 openziti/ziti-controller -f ctrl1-values.yaml --wait
+# confirm the cluster sees ctrl1 at the new version
+kubectl exec -n <namespace> <other-pod> -- ziti agent cluster list
+
+helm upgrade ziti-controller2 ... --wait
+# confirm again, then
+helm upgrade ziti-controller3 ... --wait
+```
+
+`--wait` blocks only on the local release's pod becoming `Ready`, not on the
+cluster as a whole being healthy. The intermediate `cluster list` is the only
+signal that the upgraded node has rejoined the mesh and caught up.
+
+### Pin the chart major version
+
+The chart's version and the app version are loosely coupled and chart-level
+breaking changes do happen. The v2 -> v3 transition consolidated PKI (separate
+ctrl-plane / web roots merged into one edge-signer root) and made `cluster.mode` a
+required value. Major-version chart upgrades typically need additional steps beyond
+just `helm upgrade` -- re-issuing routers' enrollments, restarting deployments,
+removing orphaned cert-manager resources. Pin to a major version in your Helm
+dependency (`^3.0.0`) so you don't get one of these silently as part of a routine
+update.
+
+### Don't change `clientApi.advertisedHost`
+
+The `clientApi.advertisedHost` value becomes part of every router and identity
+enrollment that goes through that controller. Changing it on a running release
+causes cert-manager to reissue the controller's cert with the new SAN, and existing
+routers and SDK identities will then fail to reach the controller because they were
+enrolled against the old FQDN. If you need to add a new DNS name, add it to
+`clientApi.dnsNames` or `clientApi.altDnsNames` ahead of time so it's part of the
+cert before any client needs it.
+
+### Existing operator-targeted upgrade procedure
+
+The chart's `README.md` covers the chart-version-specific steps in more detail.
+Skim it before any chart major-version upgrade, in particular the "Breaking Change"
+notes if they apply to your version transition.
+
+## Rollback
+
+If the upgrade is going wrong and you want to back out, the procedure depends on
+how far you've gotten.
+
+### Before any node finishes its first migration
+
+If you've upgraded a node, started the new binary, but the schema migration hasn't
+yet run to completion, you can stop the new binary, replace it with the previous
+version, and start that -- the on-disk state is still in the old schema and the old
+binary will pick it up.
+
+In practice this is a narrow window, because the migration runs early in startup
+and is usually fast. Don't count on being able to catch the upgrade here.
+
+### After at least one node has migrated
+
+Once the new binary has run its schema migration, the on-disk state is in the new
+schema and the old binary won't understand it. The migration is one-way. Rollback
+means restoring from the pre-upgrade snapshot you took in
+[Before You Upgrade](#before-you-upgrade-snapshot-the-cluster), following the
+[Total Cluster Loss](./failure-scenarios.md#total-cluster-loss) procedure with the
+previous binary installed on each host.
+
+You'll lose anything written to the journal between when the snapshot was taken
+and when you started the upgrade. That's why the snapshot at the start of the
+upgrade procedure matters -- it's the recovery point for this scenario.
+
+### When to actually roll back
+
+Rollback is real cluster downtime followed by a re-bootstrap; it's not a step to
+take lightly. Some heuristics:
+
+* **A single node failing to start on the new binary** is usually a config or
+  environment problem, not a reason to roll back the whole cluster. Investigate the
+  failure on that node before rolling back. The other nodes are still on the old
+  version and the cluster is in read-only mode but otherwise functional.
+* **The whole cluster behaving incorrectly after every node has been upgraded**
+  (e.g., wrong API responses, leadership flapping, routers unable to enroll) is a
+  stronger signal. If you can't isolate the problem within a short window, rolling
+  back to the snapshot is a reasonable next step.
+* **Schema-level data corruption** is the strongest signal. If something in the
+  migration produced bad on-disk state, you can't fix it forward; the snapshot is
+  the only path back to a known-good model.


### PR DESCRIPTION
- **Fix controller cluster config defaults to match source**
- **Add HA failure scenarios reference page**
- **Expand HA controller topology guide**
- **Document controller identity config and common HA bootstrapping errors**
- **Add HA cluster upgrade reference page**
- **Add HA quick-win notes from Discourse signal**
- **Expand HA cluster lifecycle and restore documentation**
- **Add HA cluster monitoring and troubleshooting reference page**
- **Add SDK client behavior section to HA failure scenarios**
- **Expand cluster config parameter docs with intent and tuning guidance**
- **Document TooManyUpdatesError and the raft rate limiter**
- **Cross-link HA operating docs from related pages**
