### PR TITLE
fix: remove duplicate createRedirects rule for identity-providers

### DIFF
--- a/docusaurus/docusaurus-plugin-openziti-docs.ts
+++ b/docusaurus/docusaurus-plugin-openziti-docs.ts
@@ -39,13 +39,6 @@ export function openzitiRedirects(routeBasePath: string = 'docs/openziti'): Plug
                 if (existingPath.startsWith(`${base}/how-to-guides/tunnelers/`)) {
                     return [existingPath.replace(`${base}/how-to-guides/tunnelers/`, `${base}/reference/tunnelers/`)];
                 }
-                // identity-providers moved from how-to-guides/external-auth/identity-providers/ to how-to-guides/identity-providers/
-                if (existingPath.startsWith(`${base}/how-to-guides/identity-providers/`)) {
-                    return [
-                        existingPath.replace(`${base}/how-to-guides/identity-providers/`, `${base}/how-to-guides/external-auth/identity-providers/`),
-                        existingPath.replace(`${base}/how-to-guides/identity-providers/`, `${base}/guides/identity-providers/`),
-                    ];
-                }
                 // guides/ renamed to how-to-guides/ (deployments, external-auth, hsm, topologies, etc.)
                 if (existingPath.startsWith(`${base}/how-to-guides/`)) {
                     return [existingPath.replace(`${base}/how-to-guides/`, `${base}/guides/`)];


### PR DESCRIPTION
The explicit redirect entry for `external-auth/identity-providers` already covers the index-page case. The `createRedirects` block added the same destination path for every page under `identity-providers/`, causing Docusaurus to try writing `external-auth/identity-providers/index.html` twice (EEXIST).