### PR TITLE
fix: restore createRedirects for identity-providers sub-pages, exclud…

### DIFF
--- a/docusaurus/docusaurus-plugin-openziti-docs.ts
+++ b/docusaurus/docusaurus-plugin-openziti-docs.ts
@@ -39,6 +39,11 @@ export function openzitiRedirects(routeBasePath: string = 'docs/openziti'): Plug
                 if (existingPath.startsWith(`${base}/how-to-guides/tunnelers/`)) {
                     return [existingPath.replace(`${base}/how-to-guides/tunnelers/`, `${base}/reference/tunnelers/`)];
                 }
+                // identity-providers sub-pages moved from external-auth/identity-providers/ to identity-providers/.
+                // Excludes the index page (handled by explicit entry) to avoid EEXIST from duplicate stub generation.
+                if (existingPath.startsWith(`${base}/how-to-guides/identity-providers/`) && existingPath !== `${base}/how-to-guides/identity-providers/`) {
+                    return [existingPath.replace(`${base}/how-to-guides/identity-providers/`, `${base}/how-to-guides/external-auth/identity-providers/`)];
+                }
                 // guides/ renamed to how-to-guides/ (deployments, external-auth, hsm, topologies, etc.)
                 if (existingPath.startsWith(`${base}/how-to-guides/`)) {
                     return [existingPath.replace(`${base}/how-to-guides/`, `${base}/guides/`)];


### PR DESCRIPTION
…e index

Removing the block in the previous commit left the 12 individual provider pages (auth0, authelia, authentik, etc.) without redirect stubs, causing the sitemap-drift check to flag them.

The original EEXIST was caused by the block matching the index page (Docusaurus passes it as .../identity-providers/ with trailing slash), generating the same stub as the explicit { from: external-auth/identity-providers } entry. The `!== identity-providers/` guard excludes only the index page; sub-pages continue to generate external-auth/identity-providers/<slug> stubs.