### PR TITLE
Apply style guide edits to network setup guides

### DIFF
--- a/docusaurus/docs/get-started/network/index.md
+++ b/docusaurus/docs/get-started/network/index.md
@@ -1,7 +1,7 @@
 # 1. Set up a network
 
-Choose a quickstart to get your OpenZiti overlay network running. All options result in a working network — pick the
-one that fits your environment.
+Choose a quickstart to get your OpenZiti overlay network running. All options result in a working network, so pick
+the one that fits your environment.
 
 :::info
 Quickstarts are short-lived networks great for learning. For production deployments, see the
@@ -10,8 +10,8 @@ Quickstarts are short-lived networks great for learning. For production deployme
 
 | Option | Best for |
 |---|---|
-| [Local — no Docker](./local-no-docker.mdx) | Fastest start; run all binaries directly on your machine |
-| [Local — with Docker](./local-with-docker.mdx) | Single container with the full stack |
-| [Local — Docker Compose](./local-docker-compose.mdx) | Multi-container setup with better service isolation |
-| [Local — Kubernetes](./local-kubernetes.mdx) | Run on a local minikube cluster |
+| [Local: No Docker](./local-no-docker.mdx) | Fastest start; run all binaries directly on your machine |
+| [Local: With Docker](./local-with-docker.mdx) | Single container with the full stack |
+| [Local: Docker Compose](./local-docker-compose.mdx) | Multi-container setup with better service isolation |
+| [Local: Kubernetes](./local-kubernetes.mdx) | Run on a local minikube cluster |
 | [Run OpenZiti anywhere](./hosted.mdx) | Deploy on an internet-accessible server; sharable with others |

--- a/docusaurus/docs/get-started/network/index.md
+++ b/docusaurus/docs/get-started/network/index.md
@@ -10,8 +10,8 @@ Quickstarts are short-lived networks great for learning. For production deployme
 
 | Option | Best for |
 |---|---|
-| [Local: No Docker](./local-no-docker.mdx) | Fastest start; run all binaries directly on your machine |
-| [Local: With Docker](./local-with-docker.mdx) | Single container with the full stack |
-| [Local: Docker Compose](./local-docker-compose.mdx) | Multi-container setup with better service isolation |
-| [Local: Kubernetes](./local-kubernetes.mdx) | Run on a local minikube cluster |
+| [Local — no Docker](./local-no-docker.mdx) | Fastest start; run all binaries directly on your machine |
+| [Local — with Docker](./local-with-docker.mdx) | Single container with the full stack |
+| [Local — Docker Compose](./local-docker-compose.mdx) | Multi-container setup with better service isolation |
+| [Local — Kubernetes](./local-kubernetes.mdx) | Run on a local minikube cluster |
 | [Run OpenZiti anywhere](./hosted.mdx) | Deploy on an internet-accessible server; sharable with others |

--- a/docusaurus/docs/get-started/network/local-docker-compose.mdx
+++ b/docusaurus/docs/get-started/network/local-docker-compose.mdx
@@ -8,19 +8,19 @@ import Wizardly from '@openziti/src/components/Wizardly';
 # Run locally with Docker Compose
 
 :::info
-Quickstarts are short-lived networks that are great for learning how to use OpenZiti. For long-lived production deployments, see [the deployment guides](@openzitidocs/category/docker).
+Quickstarts are short-lived networks that are great for learning how to use OpenZiti. For long-lived production
+deployments, see [the deployment guides](@openzitidocs/category/docker).
 :::
 
 If you are not familiar with it, [Docker Compose](https://docs.docker.com/compose/) is a tool for defining and running
 multi-container Docker applications. It makes deploying multiple containers easy by using a declarative format defined
-via yaml. Note that this page uses ["Compose V2"](https://docs.docker.com/compose/compose-v2/). This means all the 
-commands shown will reference `docker compose`, not `docker-compose`. If you're using the older style of compose, 
+via YAML. Note that this page uses ["Compose V2"](https://docs.docker.com/compose/compose-v2/). This means all the
+commands shown will reference `docker compose`, not `docker-compose`. If you're using the older style of compose,
 consider upgrading to the newer v2.
 
 ## Get the required files
 
-First, grab the compose file from the
-[ziti repository](https://get.openziti.io/dock/docker-compose.yml).
+First, grab the compose file from the [ziti repository](https://get.openziti.io/dock/docker-compose.yml).
 
 Using curl that would look like this:
 
@@ -28,14 +28,16 @@ Using curl that would look like this:
 curl -so docker-compose.yaml https://get.openziti.io/dock/docker-compose.yml
 ```
 
-Next, grab the
-default [environment file](https://get.openziti.io/dock/.env)
-or just make a file in this folder that looks like this:
+Next, grab the default [environment file](https://get.openziti.io/dock/.env) or just make a file in this folder
+that looks like this:
 
 ```text
 curl -so .env https://get.openziti.io/dock/.env
 ```
-or, if you would prefer to make your .env file manually, create a file in some way such as using the command shown below:
+
+Or, if you would prefer to make your .env file manually, create a file in some way such as using the command shown
+below:
+
 ```text
 cat > .env <<DEFAULT_ENV_FILE
 # OpenZiti Variables
@@ -51,124 +53,132 @@ DEFAULT_ENV_FILE
 ```
 
 :::caution
-If you are running Void linux, you need to modify the docker-compose file, otherwise the services will not start properly.  To do this, add the following two lines to each service definition.
+If you are running Void Linux, you need to modify the docker-compose file, otherwise the services will not start
+properly. To do this, add the following two lines to each service definition.
 
-```
+```yaml
     security_opt:
       - seccomp:unconfined
 ```
-Please see [this discussion](https://openziti.discourse.group/t/docker-compose-quickstart-setup-edge-controller-issue/601/10) for more information
+
+See [this discussion](https://openziti.discourse.group/t/docker-compose-quickstart-setup-edge-controller-issue/601/10)
+for more information.
 :::
 
 ## Run via Docker Compose
 
 Once the compose file is downloaded and the `.env` file exists, you'll be able to start this network using
-`docker compose` just like you can with any other compose file: `docker compose up`
+`docker compose` just like you can with any other compose file: `docker compose up`.
 
 :::note
-Docker compose will name your containers based on the folder you were in when you started them. For me, I've made a folder
-named `docker` so all my containers start with `docker_`. You can influence how this works by adding
-`--project-name docker` (or whatever name you like) to your `docker compose` up/down commands
+Docker compose will name your containers based on the folder you were in when you started them. For example, if
+you make a folder named `docker`, all your containers will start with `docker_`. You can influence how this works
+by adding `--project-name docker` (or whatever name you like) to your `docker compose` up/down commands.
+
 ```text
-docker compose --project-name docker up 
+docker compose --project-name docker up
 ```
 :::
 
 ### Stop the network
 
-This docker-compose file will generate a volume mount as well as a **two** docker networks. When you issue 
-`  --project-name docker down` the volume mapping will not be removed. If you wish to remove the volume, 
-you'll need to specify the `-v` flag to the `docker compose` command. Leave the `-v` off your command if you want to just 
-stop the containers without losing the controller database and PKI.
+This docker-compose file will generate a volume mount as well as *two* Docker networks. When you issue
+`docker compose --project-name docker down` the volume mapping will not be removed. If you wish to remove the
+volume, you'll need to specify the `-v` flag to the `docker compose` command. Leave the `-v` off your command if
+you want to just stop the containers without losing the controller database and Public Key Infrastructure (PKI).
 
 ## Deployment diagram
 
-The docker-compose file will create quite a few containers on your behalf. Here is a logical overview of the network that
-will get created:
+The docker-compose file will create quite a few containers on your behalf. Here is a logical overview of the
+network that will get created:
 
 ![docker-compose-overview.svg](./docker-compose-overview.svg)
 
-As you can see there's a fair bit going on in there, let's break it down. The first thing to notice is that the entire
-image is within the scope of a Docker network. You'll see with this compose file there are three pieces of the overlay
-which span the Docker network: the controller, an edge router, and a websocket-based edge router.  
+As you can see there's a fair bit going on in there, let's break it down. The first thing to notice is that the
+entire image is within the scope of a Docker network. You'll see with this compose file there are three pieces of
+the overlay which span the Docker network: the controller, an edge router, and a websocket-based edge router.
 
 ### Deployment simplified
 
-The stock docker-compose.yml deploys many components and is somewhat complex. If you prefer a simplified deployment via 
-Docker compose, one which only includes the basic controller and edge router combination you can instead download the 
-[simplified-docker-compose.yml](https://github.com/openziti/ziti/blob/release-next/quickstart/docker/simplified-docker-compose.yml)
- 
+The stock docker-compose.yml deploys many components and is somewhat complex. If you prefer a simplified
+deployment via Docker compose, one which only includes the basic controller and edge router combination, you can
+instead download the
+[simplified-docker-compose.yml](https://github.com/openziti/ziti/blob/release-next/quickstart/docker/simplified-docker-compose.yml).
+
 ### Networks
 
 Inside the Docker network you'll see there are three networks:
-* the blue docker network
-* the red docker network
-* the purple "logical" network
 
-Docker will ensure only the pieces within a given network, can only communicate within that network. This network
-topology is designed to approximate, very loosely, what it would be like to have a publicly deployed network. The purple
-network would approximate the internet itself, the blue network would represent a cloud provider's private network 
-(such as AWS) and the red network could represent another cloud provider network (like Azure). Those details are not 
-important, the important part is that the networks are totally private to one another. See more on this topic below in 
-the "Test the network" section.
+- the blue Docker network
+- the red Docker network
+- the purple "logical" network
 
-####  Purple network
+Docker will ensure only the pieces within a given network can only communicate within that network. This network
+topology is designed to approximate, very loosely, what it would be like to have a publicly deployed network. The
+purple network would approximate the internet itself, the blue network would represent a cloud provider's private
+network (such as AWS), and the red network could represent another cloud provider's network (like Azure). Those
+details are not important, the important part is that the networks are totally private to one another. See more on
+this topic below in the "Test the network" section.
 
-There is no Docker network named "purple" in the compose file, it's entirely a logical construct. It is shown only for
-clarity. All the assets in the purple network are in both the blue and red docker networks (which is why it's
-referred to as purple). The assets in the purple network need to be in both the red and blue networks because the 
-assets located in the blue and red networks need to communicate to the public edge routers and also need to communicate 
-to the controller. If that's confusing, see the "Test the network" section below which will hopefully make this more clear.
+#### Purple network
+
+There is no Docker network named "purple" in the compose file, it's entirely a logical construct. It is shown only
+for clarity. All the assets in the purple network are in both the blue and red Docker networks (which is why it's
+referred to as purple). The assets in the purple network need to be in both the red and blue networks because the
+assets located in the blue and red networks need to communicate to the public edge routers and also need to
+communicate to the controller. If that's confusing, see the "Test the network" section below, which will hopefully
+make this more clear.
 
 #### Red network
 
-The red network exists for demonstration only at this time. As you can see there are no assets inside the red network
-other than the private, `ziti-private-red` router **and** the `ziti-fabric-router-br`. This means there's nothing in the
-red network for Ziti to access. It would serve as a great place for you to put your own assets and explore using Ziti!
+The red network exists for demonstration only at this time. As you can see there are no assets inside the red
+network other than the private, `ziti-private-red` router *and* the `ziti-fabric-router-br`. This means there's
+nothing in the red network for Ziti to access. It would serve as a great place for you to put your own assets and
+explore using Ziti!
 
 #### Blue network
 
-The blue network contains two important assets, the `ziti-private-blue` router and the `web-test-blue` server. Along
-with those assets, the network also contains the `ziti-fabric-router-br`. Although the `web-test-blue` server does 
-export a port by default (port 80 on your localhost, will translate to port 8000 on the `web-test-blue` server), you 
-can use Ziti to access this server without the exported port.
+The blue network contains two important assets, the `ziti-private-blue` router and the `web-test-blue` server.
+Along with those assets, the network also contains the `ziti-fabric-router-br`. Although the `web-test-blue` server
+does export a port by default (port 80 on your localhost, will translate to port 8000 on the `web-test-blue`
+server), you can use Ziti to access this server without the exported port.
 
 #### The "Fabric" router
 
-The `ziti-fabric-router-br` exists to illustrate that you can create edge routers that are not necessarily fully public.
-This is the only router which can communicate to **all** the other routers. The Ziti mesh may choose to use this router
-if the algorithm indicates it's the fastest path. Perhaps we'll see more about this in future docs.
+The `ziti-fabric-router-br` exists to illustrate that you can create edge routers that are not necessarily fully
+public. This is the only router which can communicate to *all* the other routers. The Ziti mesh may choose to use
+this router if the algorithm indicates it's the fastest path. Perhaps we'll see more about this in future docs.
 
 ## Test the network
 
 ### Use Docker locally
 
 A quick note. If you are not well-versed with Docker you might forget that exposing ports in Docker is one thing,
-but you'll also need to have a hosts entry for the containers you want to access from outside the Docker
-network. This quickstart will expect that you understand this and for every router you add you will want to make
-sure you add a host entry. In the `docker compose` example you will want/need hosts entries for at least: 
+but you'll also need to have a hosts entry for the containers you want to access from outside the Docker network.
+This quickstart will expect that you understand this, and for every router you add you will want to make sure you
+add a host entry. In the `docker compose` example you will want/need hosts entries for at least:
 
-- `ziti-edge-controller`,
+- `ziti-edge-controller`
 - `ziti-edge-router`
 
-And if you want to expose any other routers - of course you'll need/want to have entries for those as well.
+And if you want to expose any other routers, you'll need entries for those as well.
 
 ### Test: Access the controller
 
 Now that we have used `docker compose` to deploy a relatively complicated network, we can start testing it out to make
 sure everything is in place and looks correct. Let's try it out.
 
-To test, we will `docker exec` into the running controller. Notice we'll be specifying the container and it's expected
-that the project was named "docker". If you don't start your compose using `--project-name docker`, use the proper
-exec command:
+To test, we will `docker exec` into the running controller. Notice we'll be specifying the container and it's
+expected that the project was named `docker`. If you don't start your compose using `--project-name docker`, use
+the proper exec command:
 
 ```text
 docker exec -it docker-ziti-controller-1 bash
 ```
 
-Once exec'ed into the controller, the `ziti` CLI will be added to your PATH for you. There is also the `zitiLogin`
-alias to make it easy for you to authenticate to the Ziti controller. Run `zitiLogin` now and ensure you're 
-authenticated.
+Once exec'ed into the controller, the `ziti` CLI will be added to your `PATH` for you. There is also the
+`zitiLogin` alias to make it easy for you to authenticate to the Ziti controller. Run `zitiLogin` now and ensure
+you're authenticated.
 
 ```text
 ziti@724087d30014:/persistent$ zitiLogin
@@ -179,6 +189,7 @@ Saving identity 'default' to /persistent/ziti-cli.json
 ### Test: Edge routers online
 
 Once authenticated, let's see if all our routers are online by running `ziti edge list edge-routers`:
+
 ```text
 ziti@724087d30014:/persistent$ ziti edge list edge-routers
 ╭────────────┬───────────────────────┬────────┬───────────────┬──────┬───────────────────────╮
@@ -193,7 +204,7 @@ ziti@724087d30014:/persistent$ ziti edge list edge-routers
 results: 1-5 of 5
 ```
 
-We can see all the routers are online - excellent.
+We can see all the routers are online. Excellent.
 
 ### Test: Edge router identities
 
@@ -244,7 +255,7 @@ round-trip min/avg/max/stddev = 0.633/0.633/0.633/0.000 ms
 ### Test: Underlay network connectivity failure
 
 Now let's exit the Ziti controller and instead attach to the private blue router by running this command:
-`docker exec -it docker-ziti-private-blue-1 bash`.  Once attached to the blue router we'll verify that we cannot
+`docker exec -it docker-ziti-private-blue-1 bash`. Once attached to the blue router we'll verify that we cannot
 connect to the private red router:
 
 ```text
@@ -252,11 +263,12 @@ ziti@e610d6b44166:/persistent$ ping ziti-private-red -c 1
 ping: unknown host
 ```
 
-Unknown host - the private blue router cannot connect to the red router.
+Unknown host: the private blue router cannot connect to the red router.
 
 ### Test: Underlay network web test blue
 
-While we're attached to the blue router - let's make sure we can connect to that `web-test-blue` server.  
+While we're attached to the blue router, let's make sure we can connect to that `web-test-blue` server.
+
 ```text
 ziti@e610d6b44166:/persistent$ curl http://web-test-blue:8000
 <pre>
@@ -308,7 +320,8 @@ Hello World
 </pre>
 ```
 
-Don't forget - you can also access this from the exported port 80 on your local machine too!
+Don't forget: you can also access this from the exported port 80 on your local machine too!
+
 ```text
 curl http://localhost:80
 <pre>
@@ -359,6 +372,5 @@ Hello World
 
 </pre>
 ```
-
 
 <Wizardly></Wizardly>

--- a/docusaurus/docs/get-started/network/local-kubernetes.mdx
+++ b/docusaurus/docs/get-started/network/local-kubernetes.mdx
@@ -10,13 +10,18 @@ import TabItem from '@theme/TabItem';
 # Run locally on Kubernetes
 
 :::info
-Quickstarts are short-lived networks that are great for learning how to use OpenZiti. For long-lived production deployments, see [the deployment guides](@openzitidocs/category/kubernetes).
+Quickstarts are short-lived networks that are great for learning how to use OpenZiti. For long-lived production
+deployments, see [the deployment guides](@openzitidocs/category/kubernetes).
 :::
 
-`minikube` quickly sets up a local Kubernetes cluster on macOS, Linux, or Windows (WSL). This quickstart is a great way to explore running your own controller, Router, and Console.
+`minikube` quickly sets up a local Kubernetes cluster on macOS, Linux, or Windows (WSL). This quickstart is a great
+way to explore running your own controller, router, and console.
+
 ## Tools of the trade
 
-We'll use the preferred `minikube` Docker driver for this quickstart. You can run `minikube` in WSL with Docker Engine or Docker Desktop, but keep an eye out for one extra step to run `minikube tunnel` at the necessary point in the process.
+We'll use the preferred `minikube` Docker driver for this quickstart. You can run `minikube` in WSL with Docker
+Engine or Docker Desktop, but keep an eye out for one extra step to run `minikube tunnel` at the necessary point in
+the process.
 
 1. [Install Docker](https://docs.docker.com/engine/install/)
 1. [Install `kubectl`](https://kubernetes.io/docs/tasks/tools/)
@@ -30,15 +35,17 @@ Make sure these command-line tools are available in your executable search `PATH
 
 ## Configure DNS
 
-Your computer running `minikube` needs to resolve these three domain names. They will all resolve to the same IP address where minikube exposes ingresses on your OS.
+Your computer running `minikube` needs to resolve these three domain names. They will all resolve to the same IP
+address where minikube exposes ingresses on your OS.
 
-* miniziti-controller.miniziti.internal
-* miniziti-router.miniziti.internal
+- miniziti-controller.miniziti.internal
+- miniziti-router.miniziti.internal
 
 <Tabs groupId="operating-systems">
   <TabItem value="win" label="Windows (WSL2)">
 
-   This step allows you to connect to the `minikube` ingresses from Windows or WSL. We'll need that connection to the ingresses later when we run the `ziti` CLI in WSL.
+   This step allows you to connect to the `minikube` ingresses from Windows or WSL. We'll need that connection to
+   the ingresses later when we run the `ziti` CLI in WSL.
 
 1. Enable localhost binding in WSL.
 
@@ -122,7 +129,7 @@ If Docker Desktop is not running then it may be necessary to start it in WSL, de
 
 1. In WSL, Run `minikube tunnel`.
 
-   Keep a separate terminal window open so you can make sure the tunnel is still running and provide your password if prompted. Create a "miniziti" profile if you haven't, and run the tunnel.
+   Keep a separate terminal window open so you can make sure the tunnel is still running and provide your password if prompted. Create a `miniziti` profile if you haven't, and run the tunnel.
 
    :::info
    You will likely be prompted by `minikube tunnel` for your WSL user's password, but this prompt may not occur immediately. This grants permission for the tunnel to add a route to the minikube node IP.
@@ -147,7 +154,7 @@ In macOS, `minikube` sets up localhost port forwarding to the IP of the Docker c
 
 1. Run `minikube tunnel`.
 
-   Keep a separate terminal window open so you can make sure the tunnel is still running and provide your password if prompted. Create a "miniziti" profile if you haven't, and run the tunnel.
+   Keep a separate terminal window open so you can make sure the tunnel is still running and provide your password if prompted. Create a `miniziti` profile if you haven't, and run the tunnel.
 
    :::info
    You will likely be prompted by `minikube tunnel` for your macOS user's password, but this prompt may not occur immediately. This grants permission for the tunnel to add a route to the minikube node IP.
@@ -162,7 +169,8 @@ In macOS, `minikube` sets up localhost port forwarding to the IP of the Docker c
 </TabItem>
 <TabItem value="linux" label="Linux">
 
-On Linux, the IP of the `minikube` node running in Docker is routeable via the bridge interface created by `minikube`. Create a "miniziti" profile if you haven't, and obtain the node's external IP for your hosts file.
+On Linux, the IP of the `minikube` node running in Docker is routeable via the bridge interface created by
+`minikube`. Create a `miniziti` profile if you haven't, and obtain the node's external IP for your hosts file.
 
 ```text
 minikube --profile miniziti start
@@ -177,9 +185,12 @@ sudo tee -a /etc/hosts <<< "$(minikube --profile miniziti ip) miniziti-controlle
 
 ## miniziti script
 
-You can run the miniziti shell script or perform the steps manually yourself. Click the "Manual Steps" tab directly above to switch your view.
+You can run the miniziti shell script or perform the steps manually yourself. Click the **Manual Steps** tab
+directly above to switch your view.
 
-It's recommended that you read the script before you run it. It's safe to re-run the script if it encounters a temporary problem.
+It's recommended that you read the script before you run it. It's safe to re-run the script if it encounters a
+temporary problem.
+
 <br/>
 
 [**DOWNLOAD: miniziti.bash**](https://get.openziti.io/miniziti.bash)
@@ -196,11 +207,14 @@ bash ./miniziti.bash
 
 ## Manual steps to learn by doing
 
-This section explains the actions performed by the `miniziti.bash` script.You need a BASH or ZSH terminal for pasting commands.<br/><br/>
+This section explains the actions performed by the `miniziti.bash` script. You need a Bash or Zsh terminal for
+pasting commands.
+
+<br/><br/>
 
 ### Create the `miniziti` cluster
 
-First, let's create a brand new `minikube` profile named "miniziti".
+First, let's create a brand new `minikube` profile named `miniziti`.
 
 ```text
 minikube --profile miniziti start
@@ -241,8 +255,11 @@ CoreDNS is running at https://127.0.0.1:49439/api/v1/namespaces/kube-system/serv
 
 You will need two Minikube addons:
 
-1. `ingress`: installs the Nginx ingress controller. Ingresses provide access into the cluster and are the only things exposed to networks outside the cluster. This is required by the miniziti script, but the Helm charts can be configured to use other ingress controllers.
-1. `ingress-dns`: provides a DNS server that can answer queries about the cluster's ingresses, e.g. "miniziti-controller.miniziti.internal" which will be created when you install the controller Helm chart.
+1. `ingress`: installs the Nginx ingress controller. Ingresses provide access into the cluster and are the only
+   things exposed to networks outside the cluster. This is required by the miniziti script, but the Helm charts
+   can be configured to use other ingress controllers.
+1. `ingress-dns`: provides a DNS server that can answer queries about the cluster's ingresses, e.g.
+   `miniziti-controller.miniziti.internal`, which will be created when you install the controller Helm chart.
 
 ```text
 minikube --profile miniziti addons enable ingress
@@ -279,7 +296,9 @@ Now your miniziti cluster is ready for some OpenZiti!<br/><br/>
 
 #### Allow Kubernetes to manage certificates
 
-You need to install the required [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) (CRD) for the controller.
+You need to install the required
+[Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+(CRD) for the controller.
 
 ```text
 kubectl apply \
@@ -298,7 +317,8 @@ helm repo add "openziti" https://openziti.io/helm-charts/
 
 #### Install the controller
 
-Let's create a Helm release named "miniziti-controller" for the controller. This will also install sub-charts `cert-manager` and `trust-manager` in the same Kubernetes namespace "ziti-controller."
+Let's create a Helm release named `miniziti-controller` for the controller. This will also install sub-charts
+`cert-manager` and `trust-manager` in the same Kubernetes namespace `ziti-controller`.
 
 1. Install the Controller chart
 
@@ -312,7 +332,8 @@ Let's create a Helm release named "miniziti-controller" for the controller. This
       --values https://openziti.io/helm-charts/charts/ziti-controller/values-ingress-nginx.yaml
    ```
 
-1. This may take a few minutes. Wait the controller's pod status progress to "Running." You can get started on the DNS set up in the next section, but you need the controller up and running to install the router.
+1. This may take a few minutes. Wait the controller's pod status progress to `Running`. You can get started on the
+   DNS set up in the next section, but you need the controller up and running to install the router.
 
    ```text
    kubectl wait deployments "ziti-controller" \
@@ -325,7 +346,10 @@ Let's create a Helm release named "miniziti-controller" for the controller. This
 
 Configure CoreDNS in the miniziti cluster. This is necessary no matter which host DNS resolver method you used above.
 
-1. Add the DNS query forwarder for names like *.miniziti.internal to the end of the value of `Corefile` in CoreDNS's configmap. Don't forget to substitute the real IP from `minikube --profile miniziti ip` if you get something different than "192.168.49.2", and be mindful to keep the indentation the same as the default `.:53` handler.
+1. Add the DNS query forwarder for names like *.miniziti.internal to the end of the value of `Corefile` in
+   CoreDNS's configmap. Don't forget to substitute the real IP from `minikube --profile miniziti ip` if you get
+   something different than `192.168.49.2`, and be mindful to keep the indentation the same as the default `.:53`
+   handler.
 
    ```text title="Edit as shown, save file, then exit the editor"
    kubectl edit configmap "coredns" \
@@ -391,7 +415,10 @@ Configure CoreDNS in the miniziti cluster. This is necessary no matter which hos
       --selector k8s-app=kube-dns
    ```
 
-1. Verify that the DNS names for the ingress zone, e.g. *.miniziti.internal, are resolvable from inside your cluster. This is required for your pods to communicate with the controller's advertised address.You will know it's working because you see the same IP address in the response as when you run `minikube --profile miniziti ip`.
+1. Verify that the DNS names for the ingress zone, e.g. *.miniziti.internal, are resolvable from inside your
+   cluster. This is required for your pods to communicate with the controller's advertised address. You will know
+   it's working because you see the same IP address in the response as when you run
+   `minikube --profile miniziti ip`.
 
    ```text
    kubectl run "dnstest" --rm --tty --stdin --image=busybox --restart=Never -- \
@@ -435,7 +462,8 @@ Configure CoreDNS in the miniziti cluster. This is necessary no matter which hos
       --for condition=Available=True
    ```
 
-   These Helm chart values configure the router to use the controller's cluster-internal service that provides the router control plane, i.e., the "ctrl" endpoint.
+   These Helm chart values configure the router to use the controller's cluster-internal service that provides
+   the router control plane, i.e., the `ctrl` endpoint.
 
 1. Verify the new router is "online=true"
 
@@ -461,7 +489,8 @@ Configure CoreDNS in the miniziti cluster. This is necessary no matter which hos
       --output go-template='{{"\nINFO: Your console https://miniziti-controller.miniziti.internal/zac/ password for \"admin\" is: "}}{{index .data "admin-password" | base64decode }}{{"\n\n"}}'
    ```
 
-1. Open [https://miniziti-controller.miniziti.internal/zac/](https://miniziti-controller.miniziti.internal/zac/) in your web browser and sign in with username "admin" and the password from your clipboard.
+1. Open [https://miniziti-controller.miniziti.internal/zac/](https://miniziti-controller.miniziti.internal/zac/) in
+   your web browser and sign in with username `admin` and the password from your clipboard.
 
 ### Create OpenZiti identities and services
 
@@ -500,7 +529,8 @@ ziti edge enroll /tmp/httpbin-host.jwt
 
 ### Install the `httpbin` demo API server chart
 
-This Helm chart installs an OpenZiti fork of `go-httpbin`, so it doesn't need to be accompanied by a tunneler. We'll use it as a demo API to test the service you just created named "httpbin-service".
+This Helm chart installs an OpenZiti fork of `go-httpbin`, so it doesn't need to be accompanied by a tunneler.
+We'll use it as a demo API to test the service you just created named `httpbin-service`.
 
 ```text
 helm install "miniziti-httpbin" openziti/httpbin \
@@ -515,9 +545,12 @@ helm install "miniziti-httpbin" openziti/httpbin \
 
 Add the client identity you created to your tunneler.
 
-Follow [the instructions for your tunneler OS version](https://openziti.io/docs/how-to-guides/tunnelers/) to add the identity that was saved as filename `/tmp/miniziti-client.jwt` (or WSL's "tmp" directory, e.g., `\\wsl$\Ubuntu\tmp` in Desktop Edge for Windows).
+Follow [the instructions for your tunneler OS version](https://openziti.io/docs/how-to-guides/tunnelers/) to add
+the identity that was saved as filename `/tmp/miniziti-client.jwt` (or WSL's `tmp` directory, e.g.,
+`\\wsl$\Ubuntu\tmp` in Desktop Edge for Windows).
 
-As soon as identity enrollment completes you should have a new OpenZiti DNS name available to this device. Let's test that with a DNS query.
+As soon as identity enrollment completes you should have a new OpenZiti DNS name available to this device. Let's
+test that with a DNS query.
 
 ```text title="this DNS answer is coming from the tunneler, e.g. Ziti Desktop Edge"
 nslookup httpbin.miniziti.private
@@ -531,26 +564,32 @@ The expected output includes an IP address like `100.64.0.4`.
 curl -sSf -XPOST -d ziti=awesome http://httpbin.miniziti.private/post | jq .data
 ```
 
-Visit [http://httpbin.miniziti.private/get](http://httpbin.miniziti.private/get) in your web browser in macOS, Linux, or Windows to see a JSON test response from the demo server.
+Visit [http://httpbin.miniziti.private/get](http://httpbin.miniziti.private/get) in your web browser in macOS,
+Linux, or Windows to see a JSON test response from the demo server.
 
 ## Explore the console
 
-Now that you've successfully tested the service, check out the various entities in your that were created by the script in [https://miniziti-controller.miniziti.internal/zac/](https://miniziti-controller.miniziti.private/zac/).
+Now that you've successfully tested the service, check out the various entities that were created by the script in
+[https://miniziti-controller.miniziti.internal/zac/](https://miniziti-controller.miniziti.internal/zac/).
 
 ## Next steps
 
-1. In the console, try to revoke then restore your permission to acess the demo services.
-1. Deploy a non-Ziti demo application to Kubernetes and securely [share it with a Ziti proxy pod](@openziti2x/how-to-guides/tunnelers/kubernetes/kubernetes-service)
+1. In the console, try to revoke then restore your permission to access the demo services.
+1. Deploy a non-Ziti demo application to Kubernetes and securely
+   [share it with a Ziti proxy pod](@openziti2x/how-to-guides/tunnelers/kubernetes/kubernetes-service).
 1. Add a configs, service, and policies to access the Kubernetes apiserver with OpenZiti.
-   1. Hint: the apiserver's address is "kubernetes.default.svc:443" inside the cluster.
-   1. Hint: After you create the configs, service, and policies, grant "Bind" permission for the service to "miniziti-router" by adding a role.
+   1. Hint: the apiserver's address is `kubernetes.default.svc:443` inside the cluster.
+   1. Hint: After you create the configs, service, and policies, grant `Bind` permission for the service to
+      `miniziti-router` by adding a role.
 
       ```buttonless title="the role you add needs to match the bind policy's identity roles"
       ziti edge update identity "miniziti-router" \
          --role-attributes k8sapi-hosts
       ```
 
-   1. Connect to the K8s apiserver from another computer with [`kubeztl`, the OpenZiti fork of `kubectl`](https://github.com/openziti-test-kitchen/kubeztl/). `kubeztl` works by itself without a tunneler.
+   1. Connect to the K8s apiserver from another computer with
+      [`kubeztl`, the OpenZiti fork of `kubectl`](https://github.com/openziti-test-kitchen/kubeztl/). `kubeztl`
+      works by itself without a tunneler.
 
 ## Cleanup
 
@@ -574,7 +613,7 @@ Now that you've successfully tested the service, check out the various entities 
 </TabItem>
 <TabItem value="mac" label="macOS">
 
-1. Remove the relevant `*.miniziti.internal` names from `/etc/hosts`.
+2. Remove the relevant `*.miniziti.internal` names from `/etc/hosts`.
 
    ```text
    sudo sed -iE '/miniziti.*\.internal/d' /etc/hosts
@@ -583,7 +622,7 @@ Now that you've successfully tested the service, check out the various entities 
 </TabItem>
 <TabItem value="linux" label="Linux">
 
-1. Remove the relevant `*.miniziti.internal` names from `/etc/hosts`.
+2. Remove the relevant `*.miniziti.internal` names from `/etc/hosts`.
 
    ```text
    sudo sed -iE '/miniziti.*\.internal/d' /etc/hosts
@@ -592,12 +631,12 @@ Now that you've successfully tested the service, check out the various entities 
 </TabItem>
 </Tabs>
 
-2. Delete the cluster.
+3. Delete the cluster.
 
    ```text
    minikube --profile miniziti delete
    ```
 
-2. In your tunneler, "Forget" your Identity.
+4. In your tunneler, click **Forget** to remove your identity.
 
 <Wizardly></Wizardly>

--- a/docusaurus/docs/get-started/network/local-kubernetes.mdx
+++ b/docusaurus/docs/get-started/network/local-kubernetes.mdx
@@ -613,7 +613,7 @@ Now that you've successfully tested the service, check out the various entities 
 </TabItem>
 <TabItem value="mac" label="macOS">
 
-2. Remove the relevant `*.miniziti.internal` names from `/etc/hosts`.
+1. Remove the relevant `*.miniziti.internal` names from `/etc/hosts`.
 
    ```text
    sudo sed -iE '/miniziti.*\.internal/d' /etc/hosts
@@ -622,7 +622,7 @@ Now that you've successfully tested the service, check out the various entities 
 </TabItem>
 <TabItem value="linux" label="Linux">
 
-2. Remove the relevant `*.miniziti.internal` names from `/etc/hosts`.
+1. Remove the relevant `*.miniziti.internal` names from `/etc/hosts`.
 
    ```text
    sudo sed -iE '/miniziti.*\.internal/d' /etc/hosts
@@ -631,12 +631,12 @@ Now that you've successfully tested the service, check out the various entities 
 </TabItem>
 </Tabs>
 
-3. Delete the cluster.
+1. Delete the cluster.
 
    ```text
    minikube --profile miniziti delete
    ```
 
-4. In your tunneler, click **Forget** to remove your identity.
+1. In your tunneler, click **Forget** to remove your identity.
 
 <Wizardly></Wizardly>

--- a/docusaurus/docs/get-started/network/local-no-docker.mdx
+++ b/docusaurus/docs/get-started/network/local-no-docker.mdx
@@ -9,26 +9,27 @@ import ResetQuickstart from '../../_reset-quickstart.md';
 # Run locally without Docker
 
 :::info
-Quickstarts are short-lived networks that are great for learning how to use OpenZiti. For long-lived production deployments, see [the deployment guides](@openzitidocs/category/deployments).
+Quickstarts are short-lived networks that are great for learning how to use OpenZiti. For long-lived production
+deployments, see [the deployment guides](@openzitidocs/category/deployments).
 :::
 
-This page will show you how to get your [network](@openziti2x/intro) up and running 
-quickly and easily, entirely locally. Since you'll be running everything locally, you'll have no issues communicating
-between network components. All the processes will run locally, and you'll be responsible for starting and stopping them
-when you want to turn the overlay network on or off.
+This page will show you how to get your [network](@openziti2x/intro) up and running quickly and easily, entirely
+locally. Since you'll be running everything locally, you'll have no issues communicating between network
+components. All the processes will run locally, and you'll be responsible for starting and stopping them when you
+want to turn the overlay network on or off.
 
 ## Prerequisites
 
 :::note
-Make sure you have `tar`, `hostname`, `jq` and `curl` installed before running the `expressInstall` one-liner.
+Make sure you have `tar`, `hostname`, `jq`, and `curl` installed before running the `expressInstall` one-liner.
 :::
 
 There is not much preparation necessary to getting up-and-running locally. At this time, this guide expects that
-you'll be running commands within a `bash` shell. If you're running Windows, you will need to make sure you have 
-Windows Subsystem for Linux installed for now. We plan to provide a Powershell script in the future, but for now the
-script requires you to be able to use `bash`. Make sure your local ports 1280, 6262, 10000 are free before running the
-controller. These ports are the default ports used by the controller. Also ensure ports 10080 and 3022 are open as these 
-are the default ports the edge router will use.
+you'll be running commands within a `bash` shell. If you're running Windows, you will need to make sure you have
+Windows Subsystem for Linux installed for now. We plan to provide a PowerShell script in the future, but for now
+the script requires you to be able to use `bash`. Make sure your local ports 1280, 6262, 10000 are free before
+running the controller. These ports are the default ports used by the controller. Also ensure ports 10080 and 3022
+are open, as these are the default ports the edge router will use.
 
 ## Run `expressInstall` one-liner
 
@@ -38,19 +39,19 @@ Running the latest version of Ziti locally is as simple as running this one comm
 source /dev/stdin <<< "$(wget -qO- https://get.openziti.io/ziti-cli-functions.sh)"; expressInstall
 ```
 
-This script will perform an 'express' install of Ziti which does the following:
+This script will perform an *express* install of Ziti which does the following:
 
-* download the latest version of the OpenZiti binary (`ziti`)
-* extract the binary into a predefined location: ~/.ziti/quickstart/$(hostname -s)
-* create a full PKI for you to explore
-* create a controller configuration using default values and the PKI created above
-* create an edge-router configuration using default values and the PKI created above 
-* add helper functions and environment variables to your shell (explore the script to see all)
+- download the latest version of the OpenZiti binary (`ziti`)
+- extract the binary into a predefined location: `~/.ziti/quickstart/$(hostname -s)`
+- create a full Public Key Infrastructure (PKI) for you to explore
+- create a controller configuration using default values and the PKI created above
+- create an edge-router configuration using default values and the PKI created above
+- add helper functions and environment variables to your shell (explore the script to see all)
 
 ## Start the components
 
-Once the latest version of Ziti has been downloaded and added to your path, it's time to start your controller and 
-edge-router.
+Once the latest version of Ziti has been downloaded and added to your `PATH`, it's time to start your controller
+and edge-router.
 
 ## Start your controller
 
@@ -67,31 +68,35 @@ ziti-controller started as process id: 1286. log located at: /home/vagrant/.ziti
 
 ### Verify the controller is running
 
-After running `expressInstall`, you will have environment variables set named `ZITI_CTRL_EDGE_ADVERTISED_ADDRESS` and 
-`ZITI_CTRL_EDGE_ADVERTISED_PORT`. After the controller has started, your controller should be listening at that 
-address:port combination. (Note, if you do not have these environment variables, you've probably closed your shell and opened
-it up again. You can get the environment variables by sourcing the ".env" file. 
-[See the section at the bottom of the page](#source-the-env-file)
-for details)
+After running `expressInstall`, you will have environment variables set named `ZITI_CTRL_EDGE_ADVERTISED_ADDRESS`
+and `ZITI_CTRL_EDGE_ADVERTISED_PORT`. After the controller has started, your controller should be listening at
+that address:port combination.
 
-You can see what your value is set to by running 
-`echo ${ZITI_CTRL_EDGE_ADVERTISED_ADDRESS}:${ZITI_CTRL_EDGE_ADVERTISED_PORT}`. This value defaults to: 
-`$(hostname -s):1280`. Make sure the controller is available by trying to curl to the address, and then start the edge router. 
+:::note
+If you do not have these environment variables, you've probably closed your shell and opened it up again. You can
+get the environment variables by sourcing the `.env` file. [See the section at the bottom of the
+page](#source-the-env-file) for details.
+:::
 
+You can see what your value is set to by running
+`echo ${ZITI_CTRL_EDGE_ADVERTISED_ADDRESS}:${ZITI_CTRL_EDGE_ADVERTISED_PORT}`. This value defaults to:
+`$(hostname -s):1280`. Make sure the controller is available by trying to curl to the address, and then start the
+edge router.
 
 ```text
 curl -sk "https://${ZITI_CTRL_EDGE_ADVERTISED_ADDRESS}:${ZITI_CTRL_EDGE_ADVERTISED_PORT}"
 ```
 
-Example output: 
+Example output:
+
 ```text
 {"data":{"apiVersions":{"edge":{"v1":{"apiBaseUrls":["https://your.hostname:1280/edge/client/v1"],"path":"/edge/client/v1"}},"edge-client":{"v1":{"apiBaseUrls":["https://your.hostname:1280/edge/client/v1"],"path":"/edge/client/v1"}},"edge-management":{"v1":{"apiBaseUrls":["https://your.hostname:1280/edge/management/v1"],"path":"/edge/management/v1"}}},"buildDate":"2023-06-23T15:08:25Z","revision":"65d1dda821a3","runtimeVersion":"go1.20.5","version":"v0.28.4"},"meta":{}}
 ```
 
 ### Start your edge router
 
-Now that the controller is ready, you can start the edge router created with the 'express' process. You can start this 
-router locally by running:
+Now that the controller is ready, you can start the edge router created with the *express* process. You can start
+this router locally by running:
 
 ```text
 startRouter
@@ -126,18 +131,19 @@ INFO: Controller stopped.
 
 ## Test your overlay
 
-At this point you should have a functioning [network](@openziti2x/intro). The script 
-you sourced provides another function to log in to your network. Try this now by running `zitiLogin`. You should see 
-something similar to this:
+At this point you should have a functioning [network](@openziti2x/intro). The script you sourced provides another
+function to log in to your network. Try this now by running `zitiLogin`. You should see something similar to
+this:
+
 ```text
 $ zitiLogin
 Token: 40d2d280-a633-46c9-8499-ab2e005dd222
 Saving identity 'default' to ${HOME}/.ziti/quickstart/My-Mac-mini/ziti-cli.json
 ```
 
-You can now use the `ziti` CLI to interact with Ziti!. The
-`ziti` binary is not added to your path by default but will be available at `"${ZITI_BIN_DIR-}/ziti"`. Add that folder
-to your path, alias `ziti` if you like. Let's try to use this command to see if the edge router is online by running:
+You can now use the `ziti` CLI to interact with Ziti! The `ziti` binary is not added to your `PATH` by default but
+will be available at `"${ZITI_BIN_DIR-}/ziti"`. Add that folder to your `PATH`, alias `ziti` if you like. Let's try
+to use this command to see if the edge router is online by running:
 `"${ZITI_BIN_DIR-}/ziti" edge list edge-routers`.
 
 ```text
@@ -146,7 +152,7 @@ id: rhx6687N.P    name: My-Mac-mini    isOnline: true    role attributes: {}
 results: 1-1 of 1
 ```
 
-Horray! Our edge router shows up and is online!
+Hooray! Our edge router shows up and is online!
 
 ## Run your first service
 
@@ -156,26 +162,25 @@ You can try out creating and running a simple echo service through ziti by runni
 $ "${ZITI_BIN_DIR-}/ziti" demo first-service
 ```
 
-
 ## Customize the express install
 
-You can influence and customize the express installation somewhat if you wish. This is useful if trying to run more than
-one instance of Ziti locally. The most common settings you might choose to customize would be the ports used or the name
-of the network. 
+You can influence and customize the express installation somewhat if you wish. This is useful if trying to run
+more than one instance of Ziti locally. The most common settings you might choose to customize would be the ports
+used or the name of the network.
 
 ### Configuration file location
 
-You can change the location of the configuration files output by setting the `ZITI_NETWORK` environment variable prior 
-to running `expressInstall`. However, if you do this you will also need to set other environment variables as well. 
-Please realize that if you change these variables each of the "hostname" variables will need to be addressable:
+You can change the location of the configuration files output by setting the `ZITI_NETWORK` environment variable
+prior to running `expressInstall`. However, if you do this you will also need to set other environment variables
+as well. Realize that if you change these variables, each of the hostname variables will need to be addressable:
 
-* ZITI_CTRL_EDGE_ADVERTISED_ADDRESS
-* ZITI_CTRL_EDGE_ADVERTISED_PORT
-* ZITI_ROUTER_ADVERTISED_ADDRESS
-* ZITI_ROUTER_PORT
+- `ZITI_CTRL_EDGE_ADVERTISED_ADDRESS`
+- `ZITI_CTRL_EDGE_ADVERTISED_PORT`
+- `ZITI_ROUTER_ADVERTISED_ADDRESS`
+- `ZITI_ROUTER_PORT`
 
-Here is an example which allows you to put all the files into a folder called: `${HOME}/.ziti/quickstart/newfolder`, uses
-a host named 'localhost', and uses ports 8800 for the edge controller and 9090 for the edge router:
+Here is an example which allows you to put all the files into a folder called `${HOME}/.ziti/quickstart/newfolder`,
+uses a host named `localhost`, and uses ports 8800 for the edge controller and 9090 for the edge router:
 
 ```text
 ZITI_NETWORK="newfolder"; \
@@ -188,10 +193,10 @@ source ziti-cli-functions.sh; expressInstall
 
 ## Source the env file
 
-In the case you close your shell and you want to get the same environment variables back into your shell, you can just 
-source the "env" file that is placed into the location you specified. This file is usually located at:
-`$HOME/.ziti/quickstart/$(hostname)/$(hostname).env`. You can source this file to place the environment variables back
-into your shell.
+In the case you close your shell and you want to get the same environment variables back into your shell, you can
+just source the `.env` file that is placed into the location you specified. This file is usually located at
+`$HOME/.ziti/quickstart/$(hostname)/$(hostname).env`. You can source this file to place the environment variables
+back into your shell.
 
 ```text
 source $HOME/.ziti/quickstart/$(hostname)/$(hostname).env
@@ -200,6 +205,5 @@ source $HOME/.ziti/quickstart/$(hostname)/$(hostname).env
 ## Reset the quickstart
 
 <ResetQuickstart/>
-
 
 <Wizardly></Wizardly>

--- a/docusaurus/docs/get-started/network/local-with-docker.mdx
+++ b/docusaurus/docs/get-started/network/local-with-docker.mdx
@@ -8,65 +8,69 @@ import Wizardly from '@openziti/src/components/Wizardly';
 # Run locally in a Docker container
 
 :::info
-Quickstarts are short-lived networks that are great for learning how to use OpenZiti. For long-lived production deployments, see [the deployment guides](@openzitidocs/category/docker).
+Quickstarts are short-lived networks that are great for learning how to use OpenZiti. For long-lived production
+deployments, see [the deployment guides](@openzitidocs/category/docker).
 :::
 
-[Docker](https://www.docker.com) is a popular container engine, and many developers enjoy using solutions delivered via
-Docker. Ziti provides a single Docker container which contains the entire stack of Ziti components. This is not the most
-common mechanism for deploying containers, we recognize that. However, we think that this makes it a bit easier for
-people to get started with deploying Ziti components using Docker. We will certainly look to create individual
-containers for each component in the future but for now it's a single container. You can get this container by issuing
-`docker pull openziti/quickstart:latest`.
+[Docker](https://www.docker.com) is a popular container engine, and many developers enjoy using solutions delivered
+via Docker. Ziti provides a single Docker container which contains the entire stack of Ziti components. This is not
+the most common mechanism for deploying containers, we recognize that. However, we think that this makes it a bit
+easier for people to get started with deploying Ziti components using Docker. We will certainly look to create
+individual containers for each component in the future but for now it's a single container. You can get this
+container by issuing `docker pull openziti/quickstart:latest`.
 
 ## Start the controller
 
-All [networks](@openziti2x/intro) require
-a [controller](../../how-to-guides/deployments/10-linux/10-controller/10-deploy.mdx). Without a controller, edge routers won't be able to authorize new
-connections rendering a new network useless. You must have a controller running.
+All [networks](@openziti2x/intro) require a
+[controller](../../how-to-guides/deployments/10-linux/10-controller/10-deploy.mdx). Without a controller, edge
+routers won't be able to authorize new connections, rendering a new network useless. You must have a controller
+running.
 
 ### Required: Docker named volume
 
-Running Ziti locally via Docker will require you to create a "named volume" in docker where any and all persistent files
-will be saved.
+Running Ziti locally via Docker will require you to create a "named volume" in Docker where any and all persistent
+files will be saved.
 
 Create the named volume now using this command:
+
 ```text
 docker volume create myPersistentZitiFiles
 ```
 
 ### Required: Docker network
 
-Other containers on the Docker network will **need** to address the controller. To do this, the container requires
-a network alias. This forces you to add the container to a network which is not the default network. 
+Other containers on the Docker network will *need* to address the controller. To do this, the container requires a
+network alias. This forces you to add the container to a network which is not the default network.
 
-Create the docker network now using this command:
+Create the Docker network now using this command:
+
 ```text
 docker network create myFirstZitiNetwork
 ```
 
-When starting containers participating in this network, the docker network name will be supplied as a parameter
-to the `docker` command. It's important for containers to be able to address other containers on the docker network,
-this requires predictable container names on the docker network. When looking at the example commands below, these
+When starting containers participating in this network, the Docker network name will be supplied as a parameter to
+the `docker` command. It's important for containers to be able to address other containers on the Docker network,
+this requires predictable container names on the Docker network. When looking at the example commands below, these
 options are the ones controlling the network name and network alias on the network:
 `--network myFirstZitiNetwork --network-alias ziti-controller`.
 
 ### Optional: Expose controller port
 
-Docker containers by default won't expose any ports that you could use from your local machine. If you want to be able
-to use this controller from outside of Docker, you'll need to export the controller's API port. That's easy to do, 
-simply pass one more parameter to the `docker` command: `-p ${externalPort}:${internalPort}`
+Docker containers by default won't expose any ports that you could use from your local machine. If you want to be
+able to use this controller from outside of Docker, you'll need to export the controller's API port. That's easy to
+do, simply pass one more parameter to the `docker` command: `-p ${externalPort}:${internalPort}`.
 
 ### Run the controller
 
-Here's an example of how to launch a controller using the folder created in the steps above. Also, notice this command
-passes a couple extra flags you'll see used on this page. Notably
-the `--rm` flag and the `-it` flag. The `--rm` flag instructs Docker to delete the container when the container exits.
-The `-it` flag will run the container interactively. Running interactively like this makes it easier to see the logs
-produced, but you will need a terminal for each process you want to run. The choice is yours, but in these examples 
-we'll use `-it` to make seeing the output from the logs easier.
+Here's an example of how to launch a controller using the folder created in the steps above. Also, notice this
+command passes a couple extra flags you'll see used on this page. Notably the `--rm` flag and the `-it` flag. The
+`--rm` flag instructs Docker to delete the container when the container exits. The `-it` flag will run the
+container interactively. Running interactively like this makes it easier to see the logs produced, but you will
+need a terminal for each process you want to run. The choice is yours, but in these examples we'll use `-it` to
+make seeing the output from the logs easier.
 
-Here's an example which will use the Docker network named "myFirstZitiNetwork" and expose the controller to your local
-computer on port 1280 (the default port).
+Here's an example which will use the Docker network named `myFirstZitiNetwork` and expose the controller to your
+local computer on port 1280 (the default port).
 
 ```text
 docker run \
@@ -84,12 +88,14 @@ docker run \
 ```
 
 ## Create edge router policies
-OpenZiti requires explicit authorization of identities using ([edge router policies](../../reference/glossary.mdx#edge-router-policy)), 
-as well as authorization of services and routers using ([service edge router policies](../../reference/glossary.mdx#service-edge-router-policy)). 
-The docker-based quickstart doesn't perform these steps automatically. Run the initialization container one time, after 
-starting the controller as shown
 
-```textell
+OpenZiti requires explicit authorization of identities using
+[edge router policies](../../reference/glossary.mdx#edge-router-policy), as well as authorization of services and
+routers using [service edge router policies](../../reference/glossary.mdx#service-edge-router-policy). The
+Docker-based quickstart doesn't perform these steps automatically. Run the initialization container one time,
+after starting the controller as shown:
+
+```text
 docker run \
   --network myFirstZitiNetwork \
   --network-alias ziti-controller-init-container \
@@ -102,14 +108,14 @@ docker run \
 
 ## Edge router
 
-At this point you should have a [controller](../../how-to-guides/deployments/10-linux/10-controller/10-deploy.mdx) running. You should have created your
-Docker network as well as creating the volume mount. Now it's time to connect your first edge router. The same Docker
-image that runs the controller can run an edge router. To start an edge router, you will run a very similar command as
-the one to start the controller with a couple of key differences.
+At this point you should have a [controller](../../how-to-guides/deployments/10-linux/10-controller/10-deploy.mdx)
+running. You should have created your Docker network as well as created the volume mount. Now it's time to connect
+your first edge router. The same Docker image that runs the controller can run an edge router. To start an edge
+router, you will run a very similar command as the one to start the controller with a couple of key differences.
 
-The first noticeable difference is that we need to pass in the name of the edge router we want it to be. To use this
-network, the name supplied needs tobe addressable by clients.  Also notice the port exported is port 3022. This is the
-default port used by edge routers. 
+The first noticeable difference is that we need to pass in the name of the edge router we want it to be. To use
+this network, the name supplied needs to be addressable by clients. Also notice the port exported is port 3022.
+This is the default port used by edge routers.
 
 ```text
 docker run \
@@ -127,7 +133,8 @@ docker run \
   /var/openziti/scripts/run-router.sh edge
 ```
 
-If you want to create a second edge router, you'll need to override the router port, don't forget to export that port too
+If you want to create a second edge router, you'll need to override the router port. Don't forget to export that
+port too.
 
 ```text
 docker run \
@@ -150,23 +157,24 @@ docker run \
 
 ### Use Docker locally
 
-Using the network outside the docker environment is somewhat complex. The aliases chosen when starting the docker
-containers need to be addressable from wherever a client is connecting. This includes the `ziti` CLI, tunnelers, SDKs,
-etc. This quickstart expects you understand this and every router added to the overlay will require a route to the alias
-used. The easiest way to accomplish this is to use the operating system's ["hosts file"](https://en.wikipedia.org/wiki/Hosts_(file))
-but a nameserver such as a [pi hole](https://pi-hole.net/) also works well. Understanding this concept in-depth is out
-of scope of this guide. It is assumed you have added the following entries to your operating
-system's hosts file or DNS nameserver:
-* `ziti-edge-controller`
-* `ziti-edge-router-1`
-* `ziti-edge-router-2`
+Using the network outside the Docker environment is somewhat complex. The aliases chosen when starting the Docker
+containers need to be addressable from wherever a client is connecting. This includes the `ziti` CLI, tunnelers,
+SDKs, etc. This quickstart expects you understand this, and every router added to the overlay will require a route
+to the alias used. The easiest way to accomplish this is to use the operating system's
+[`hosts file`](https://en.wikipedia.org/wiki/Hosts_(file)) but a nameserver such as [Pi-hole](https://pi-hole.net/)
+also works well. Understanding this concept in-depth is out of scope of this guide. It is assumed you have added
+the following entries to your operating system's hosts file or DNS nameserver:
+
+- `ziti-edge-controller`
+- `ziti-edge-router-1`
+- `ziti-edge-router-2`
 
 ### Test the router is online
 
-With the controller and router running, you can now attach to the Docker host running the Ziti controller and test that
-the router did indeed come online and is running as you expect. To do this, we'll use another feature of the `docker`
-command and `exec` into the machine. First, you'll need to know your Docker container name which you can figure out by
-running `docker ps`.
+With the controller and router running, you can now attach to the Docker host running the Ziti controller and test
+that the router did indeed come online and is running as you expect. To do this, we'll use another feature of the
+`docker` command and `exec` into the machine. First, you'll need to know your Docker container name which you can
+figure out by running `docker ps`.
 
 ```text
 $ docker ps
@@ -177,11 +185,11 @@ CONTAINER ID   IMAGE                 COMMAND                  CREATED          S
 a33d58248d6e   openziti/quickstart   "/var/openziti/scripts/r…"   46 minutes ago   Up 46 minutes   0.0.0.0:1280->1280/tcp, :::1280->1280/tcp   xenodochial_cori
 ```
 
-Above, you'll see my controller is running in a container named "xenodochial_cori". I can tell because it's using the
-default port of 1280, the default port for the controller. Now I can `exec` into this
-container: `docker exec -it xenodochial_cori /bin/bash`
+Above, you'll see your controller is running in a container named `xenodochial_cori`. You can tell because it's
+using the default port of 1280, the default port for the controller. Now you can `exec` into this container:
+`docker exec -it xenodochial_cori /bin/bash`.
 
-Once in the container, I can now issue `zitiLogin` to authenticate the `ziti` CLI.
+Once in the container, you can now issue `zitiLogin` to authenticate the `ziti` CLI.
 
 ```text
 zitiLogin
@@ -189,14 +197,13 @@ Token: b16f182f-88b3-4fcc-9bfc-1e32319ca486
 Saving identity 'default' to /persistent/ziti-cli.json
 ```
 
-And finally, once authenticated I can test to see if the edge router is online in the controller and as you'll see, the
-`isOnline` property is true!
+And finally, once authenticated you can test to see if the edge router is online in the controller and as you'll
+see, the `isOnline` property is true!
 
 ```text
 ziti@a33d58248d6e:/persistent$ ziti edge list edge-routers
 id: qNZyqZEix3    name: ziti-edge-router-1    isOnline: true    role attributes: {}
 results: 1-1 of 1
 ```
-
 
 <Wizardly></Wizardly>


### PR DESCRIPTION
Brings the "Set up a network" get-started pages into line with the docs style guide.