### PR TITLE
Apply style guide edits to get-started intro pages and CLI password partial

### DIFF
--- a/docusaurus/docs/_cli-change-password.md
+++ b/docusaurus/docs/_cli-change-password.md
@@ -1,6 +1,4 @@
-
-
-If a user identity has a password authenticator (`updb`) then you may change the password with the CLI.
+If a user identity has a password authenticator (`updb`), you can change the password with the CLI.
 
 ```text
 ziti edge update authenticator updb -s

--- a/docusaurus/docs/get-started/index.md
+++ b/docusaurus/docs/get-started/index.md
@@ -15,7 +15,6 @@ the community for help!
 
 ## What you'll do
 
-1. **[Set up a network](./network/index.md)** — pick a quickstart to get your overlay network running.
-2. **[Install the ZAC](./zac/index.mdx)** — optional web UI for managing your network.
-3. **[Create your first service](./services/index.md)** — secure an existing app with zero trust.
-
+1. **[Set up a network](./network/index.md)**: pick a quickstart to get your overlay network running.
+2. **[Install the ZAC](./zac/index.mdx)**: optional web UI for managing your network.
+3. **[Create your first service](./services/index.md)**: secure an existing app with zero trust.

--- a/docusaurus/docs/get-started/network/hosted.mdx
+++ b/docusaurus/docs/get-started/network/hosted.mdx
@@ -9,15 +9,19 @@ import ResetQuickstart from '../../_reset-quickstart.md';
 # Run OpenZiti anywhere
 
 :::info
-Quickstarts are short-lived networks that are great for learning how to use OpenZiti. For long-lived production deployments, see [the deployment guides](@openzitidocs/category/deployments).
+Quickstarts are short-lived networks that are great for learning how to use OpenZiti. For long-lived production
+deployments, see [the deployment guides](@openzitidocs/category/deployments).
 :::
 
-You can absolutely choose to host your [network](@openziti2x/intro) anywhere you like.
-It is not necessary for the server to be on the open internet. If it works better for you to deploy OpenZiti on your
-own network, great, do that.  The only requirement to be aware of is that every piece of the network will need to be able to communicate to the controller and at least one edge router, which this quickstart will provide.
+You can absolutely choose to host your [network](@openziti2x/intro) anywhere you like. It is not necessary for the
+server to be on the open internet. If it works better for you to deploy OpenZiti on your own network, great, do
+that. The only requirement to be aware of is that every piece of the network will need to be able to communicate to
+the controller and at least one edge router, which this quickstart will provide.
 
-If you have a Linux server available on the open internet, or you will provision one for use with OpenZiti, that's the
-ideal scenario. With a zero trust overlay network provided by OpenZiti, you can rest assured that your traffic is safe even when using commodity internet. Furthermore, you do not need to worry about being on a network you trust, as all networks are considered untrustworthy, even your work/home network!
+If you have a Linux server available on the open internet, or you will provision one for use with OpenZiti, that's
+the ideal scenario. With a zero trust overlay network provided by OpenZiti, you can rest assured that your traffic
+is safe even when using commodity internet. Furthermore, you do not need to worry about being on a network you
+trust, as all networks are considered untrustworthy, even your work/home network!
 
 ## Installation
 
@@ -36,26 +40,31 @@ open a range of ports through your firewall:
 - `8442/tcp`: edge router providing client connections
 - `8443/tcp`: Ziti Admin Console (ZAC) [optional]
 
-These are the arbitrary ports we'll use in this example for convenience when specifying the firewall exception as a port range.
+These are the arbitrary ports we'll use in this example for convenience when specifying the firewall exception as
+a port range.
 
 ## Express install
 
 ### Prerequisites
 
 :::note
-Make sure you have `tar`, `hostname`, `jq` and `curl` installed before running the `expressInstall` one-liner.
+Make sure you have `tar`, `hostname`, `jq`, and `curl` installed before running the `expressInstall` one-liner.
 :::
 
 ### `expressInstall` setup {#expressinstall-setup}
 
-`expressInstall` may be customized with environment variables. Consider creating a DNS name for this installation before running the script. By default, the
-quickstart will install your Ziti network's PKI and configuration files in `${HOME}/.ziti/quickstart/$(hostname -s)`. You may choose a different location by defining `ZITI_HOME=/custom/path/to/quickstart`. If you do customize `ZITI_HOME` then you should also make this assignment in your shell RC, e.g., `~/.bashrc` for future convenience.
+`expressInstall` may be customized with environment variables. Consider creating a DNS name for this installation
+before running the script. By default, the quickstart will install your Ziti network's Public Key Infrastructure
+(PKI) and configuration files in `${HOME}/.ziti/quickstart/$(hostname -s)`. You may choose a different location by
+defining `ZITI_HOME=/custom/path/to/quickstart`. If you do customize `ZITI_HOME` then you should also make this
+assignment in your shell RC, e.g., `~/.bashrc` for future convenience.
 
-You will almost certainly want to use the **public** DNS name
-of your instance. It is possible to use an IP address, but a DNS name is a more flexible option, which will be important if the IP ever changes.
+You will almost certainly want to use the *public* DNS name of your instance. It is possible to use an IP address,
+but a DNS name is a more flexible option, which will be important if the IP ever changes.
 
-The quickest and easiest thing to do, is find your external DNS name and set it into the `EXTERNAL_DNS` environment
-variable. You may skip setting `EXTERNAL_DNS` if you don't need to configure the advertised DNS Subject Alternative Name (SAN). For example,
+The quickest and easiest thing to do is find your external DNS name and set it into the `EXTERNAL_DNS` environment
+variable. You may skip setting `EXTERNAL_DNS` if you don't need to configure the advertised DNS Subject Alternative
+Name (SAN). For example,
 
 ```text
 export EXTERNAL_DNS="acme.example.com"
@@ -75,9 +84,8 @@ export ZITI_ROUTER_PORT=8442
 
 ### Run `expressInstall`
 
-As with any script that is downloaded and run from the internet, we recommend you examine 
-the script before running it locally. This script is provided as a convenience
-method for installing an environment quickly and easily.
+As with any script that is downloaded and run from the internet, we recommend you examine the script before running
+it locally. This script is provided as a convenience method for installing an environment quickly and easily.
 
 ```text
 source /dev/stdin <<< "$(wget -qO- https://get.openziti.io/ziti-cli-functions.sh)"; expressInstall
@@ -85,8 +93,10 @@ source /dev/stdin <<< "$(wget -qO- https://get.openziti.io/ziti-cli-functions.sh
 
 ### `systemd` {#systemd}
 
-This assumes you already ran `expressInstall` on a Linux server. If it's available on your system, then it is recommended to use `systemd` to manage your controller and router processes. This
-is useful to make sure the controller can restart automatically should you shutdown/restart the server. To generate the `systemd` unit files, run:
+This assumes you already ran `expressInstall` on a Linux server. If it's available on your system, then it is
+recommended to use `systemd` to manage your controller and router processes. This is useful to make sure the
+controller can restart automatically should you shutdown/restart the server. To generate the `systemd` unit files,
+run:
 
 ```text
 createControllerSystemdFile
@@ -105,12 +115,13 @@ Router systemd file written to: /home/ubuntu/.ziti/quickstart/ip-172-31-23-18/ip
 
 #### The helper functions vs systemd
 
-The set of startController/stopController, startRouter/stopRouter are functions declared in the 
-[the ziti-cli-function.sh helper script](https://get.openziti.io/ziti-cli-functions.sh) and are useful for running
-the controller and router directly in your shell. These functions are not meant to work with systemd-enabled installs. If
-you are enabling systemd, use `systemctl` to start/stop the components. During the expressInstall, the controller and router
-were started using the helper scripts to complete the installation. Both should not be running, but before you run the 
-controller and router with `systemd` you need to stop them if they're currently running:
+The set of `startController` / `stopController`, `startRouter` / `stopRouter` are functions declared in
+[the ziti-cli-functions.sh helper script](https://get.openziti.io/ziti-cli-functions.sh) and are useful for running
+the controller and router directly in your shell. These functions are not meant to work with systemd-enabled
+installs. If you are enabling systemd, use `systemctl` to start/stop the components. During the `expressInstall`,
+the controller and router were started using the helper scripts to complete the installation. Both should not be
+running, but before you run the controller and router with `systemd` you need to stop them if they're currently
+running:
 
 ```text
 stopRouter 
@@ -137,9 +148,8 @@ sudo systemctl enable --now ziti-controller
 sudo systemctl enable --now ziti-router
 ```
 
-Now, both the controller and the edge router will restart automatically if the machine reboots!  
-After a few seconds you can then run these commands and verify systemd has started the processes 
-and see the status:
+Now, both the controller and the edge router will restart automatically if the machine reboots! After a few seconds
+you can then run these commands and verify systemd has started the processes and see the status:
 
 ```text
 sudo systemctl -q status ziti-controller --lines=0 --no-pager
@@ -191,7 +201,5 @@ $ echo $ZITI_HOME
 ## Reset the quickstart
 
 <ResetQuickstart/>
-
-
 
 <Wizardly></Wizardly>

--- a/docusaurus/docs/get-started/services/index.md
+++ b/docusaurus/docs/get-started/services/index.md
@@ -1,34 +1,42 @@
 ---
 ---
+
 # 3. Create your first service
 
-This document will demonstrate how to successfully deploy and secure an existing, "brown field" application using OpenZiti. You want to 
-secure an application where you don't control the source or where you don't want to (or cannot) integrate an OpenZiti SDK into the 
-application. These sorts of services are often web-based, so we'll focus here at exposing a web server. It's important to keep in mind 
-that OpenZiti is a holistic zero trust networking solution. You can absolutely expose applications that are not web-based. For now, we'll start with a web server since that's a common need. 
+This document will demonstrate how to successfully deploy and secure an existing, *brown field* application using
+OpenZiti. You want to secure an application where you don't control the source or where you don't want to (or
+cannot) integrate an OpenZiti SDK into the application. These sorts of services are often web-based, so we'll
+focus here at exposing a web server. It's important to keep in mind that OpenZiti is a holistic zero trust
+networking solution. You can absolutely expose applications that are not web-based. For now, we'll start with a
+web server since that's a common need.
 
 ---
 
 ## Solution overview
 
-Before we get into using OpenZiti, let's take a moment and review what the solution is like before we apply any zero trust networking 
-principles. We will use some sort of http client, connect it over a network. The exact network does not matter. OpenZiti is applicable 
-to any network be it host network, local network, the internet, private network, etc. 
+Before we get into using OpenZiti, let's take a moment and review what the solution is like before we apply any
+zero trust networking principles. We will use some sort of HTTP client, connect it over a network. The exact
+network does not matter. OpenZiti is applicable to any network be it host network, local network, the internet,
+private network, etc.
 
 ### Simple HTTP solution overview: Before OpenZiti
+
 ![before OpenZiti](./before-openziti.png)
 
-The important aspect of this diagram is to notice that the HTTP server is provisioned on the [underlay](../../reference/glossary.mdx#underlay)
-network and requires a hole through the firewall to allow clients to connect.
+The important aspect of this diagram is to notice that the HTTP server is provisioned on the
+[underlay](../../reference/glossary.mdx#underlay) network and requires a hole through the firewall to allow
+clients to connect.
 
 ### Simple HTTP solution: After OpenZiti
+
 ![after OpenZiti](./after-openziti.png)
 
-After OpenZiti, we can see that there is no longer an open firewall to allow access to the HTTP server. Instead, the HTTP client 
-will have its network requests intercepted by an OpenZiti tunneler. Once intercepted, the packets are then delivered to the OpenZiti
-[overlay](../../reference/glossary.mdx#network-overlay-overlay) fabric which has the responsibility to deliver the intercepted packets to the
-target identity. Once delivered to the target identity, in this example, the traffic will offload back to the underlay network to be 
-sent to the final destination: the HTTP Server.
+After OpenZiti, we can see that there is no longer an open firewall to allow access to the HTTP server. Instead,
+the HTTP client will have its network requests intercepted by an OpenZiti tunneler. Once intercepted, the packets
+are then delivered to the OpenZiti [overlay](../../reference/glossary.mdx#network-overlay-overlay) fabric which
+has the responsibility to deliver the intercepted packets to the target identity. Once delivered to the target
+identity, in this example, the traffic will offload back to the underlay network to be sent to the final
+destination: the HTTP server.
 
 With an understanding of what we are looking to accomplish in this guide, let's get into it!
 
@@ -37,52 +45,62 @@ With an understanding of what we are looking to accomplish in this guide, let's 
 ## Implement the service
 
 ### Prerequisite: OpenZiti
+
 You will need an OpenZiti overlay network in place before you can complete this guide. If you do not have an
-OpenZiti overlay network provisioned yet, [follow a quickstart](@openziti2x/get-started) and get a network up and running.
+OpenZiti overlay network provisioned yet, [follow a quickstart](@openziti2x/get-started) and get a network up and
+running.
 
 ### Prerequisite: HTTP server
-You'll need an HTTP server which you plan to connect your HTTP client to. There are numerous ways to 
-bring an HTTP server online but for this guide I have chosen to use docker and deploy a very simple HTTP application. The server will 
-simply print out the "docker whale" when it's connected to. (This guide will not teach you how to install docker, nor how to install an 
-HTTP server which is listening)  If you are familiar with docker and wish to use the exact same example as shown here, simply run the 
-container with: `docker run -d --rm --name web-test -p 80:8000 openziti/hello-world`. 
 
-If you have used the [Local - Docker Compose](../network/local-docker-compose.mdx) quickstart 
-to provision your OpenZiti overlay network, you will have already this HTTP server available to use immediately. 
+You'll need an HTTP server which you plan to connect your HTTP client to. There are numerous ways to bring an HTTP
+server online, but for this guide we've chosen to use Docker and deploy a very simple HTTP application. The server
+will simply print out the *Docker whale* when it's connected to. This guide will not teach you how to install
+Docker, nor how to install an HTTP server which is listening. If you are familiar with Docker and wish to use the
+exact same example as shown here, simply run the container with:
+`docker run -d --rm --name web-test -p 80:8000 openziti/hello-world`.
+
+If you have used the [Local: Docker Compose](../network/local-docker-compose.mdx) quickstart to provision your
+OpenZiti overlay network, you will already have this HTTP server available to use immediately.
 
 ### Prerequisite: HTTP client tunneler
-You will need to install an [OpenZiti tunneler](../../how-to-guides/tunnelers/index.mdx) on the machine which represents the HTTP client. Later on 
-we'll create an identity for this tunneler and use the identity to access the HTTP server. 
+
+You will need to install an [OpenZiti tunneler](../../how-to-guides/tunnelers/index.mdx) on the machine which
+represents the HTTP client. Later on we'll create an identity for this tunneler and use the identity to access the
+HTTP server.
 
 ### Prerequisite: HTTP server tunneler
-You will need to install an [OpenZiti tunneler](../../how-to-guides/tunnelers/index.mdx) on the machine which represents the HTTP server. Later on
-we'll create an identity for this tunneler and use the identity to access the HTTP server. 
+
+You will need to install an [OpenZiti tunneler](../../how-to-guides/tunnelers/index.mdx) on the machine which
+represents the HTTP server. Later on we'll create an identity for this tunneler and use the identity to access the
+HTTP server.
 
 :::note
-If you used the docker-compose quickstart the "private" edge routers are configured as tunnelers and will not require you to deploy 
-another tunneler nor will you need to create another identity.
+If you used the docker-compose quickstart the `private` edge routers are configured as tunnelers and will not
+require you to deploy another tunneler nor will you need to create another identity.
 :::
-> 
-### Prerequisite: CLI
-If you plan to use the `ziti` CLI tool, you will need to download and get the `ziti` executable on your path. If you have 
-followed the [Local - No Docker](../network/local-no-docker.mdx) quickstart, this will have been done for you and the executable will be located in `~/.ziti/quickstart/$(hostname -s)/ziti-bin/`.
-Also, the .env file the quickstart emits can be used to put this folder on your path by simply sourcing that file. For example, if you
-followed either the [Local - No Docker](../network/local-no-docker.mdx) or 
-[Run OpenZiti anywhere](../network/hosted.mdx) quickstart, you should have a file that can be sourced. Here is an example of 
-my personal "Local - No Docker" result when sourcing that file:
 
-```textell
+### Prerequisite: CLI
+
+If you plan to use the `ziti` CLI tool, you will need to download and get the `ziti` executable on your `PATH`. If
+you have followed the [Local: No Docker](../network/local-no-docker.mdx) quickstart, this will have been done for
+you and the executable will be located in `~/.ziti/quickstart/$(hostname -s)/ziti-bin/`. Also, the `.env` file the
+quickstart emits can be used to put this folder on your `PATH` by simply sourcing that file. For example, if you
+followed either the [Local: No Docker](../network/local-no-docker.mdx) or
+[Run OpenZiti anywhere](../network/hosted.mdx) quickstart, you should have a file that can be sourced. Here is an
+example of a Local: No Docker result when sourcing that file:
+
+```text
 $ source ~/.ziti/quickstart/$(hostname -s)/$(hostname -s).env
 
 adding /home/cd/.ziti/quickstart/sg3/ziti-bin/ziti-v0.25.6 to the path
 ```
 
-If you are using a docker-based example you can exec into the controller where the `ziti` CLI tool will be available and 
-the env file which adds `ziti` to your path will be sourced for you as well. 
+If you are using a Docker-based example you can exec into the controller where the `ziti` CLI tool will be
+available and the env file which adds `ziti` to your `PATH` will be sourced for you as well.
 
 Here's an example command using `docker` to exec into the controller container:
 
-```textell
+```text
 $ docker exec -it docker_ziti-controller_1 bash
 
 adding /var/openziti/ziti-bin to the path
@@ -92,50 +110,55 @@ adding /var/openziti/ziti-bin to the path
 
 ### Configure the overlay: Overview
 
-With our overlay network ready and with two tunneling applications deployed and ready to be used, we can start to configure our solution.
+With our overlay network ready and with two tunneling applications deployed and ready to be used, we can start to
+configure our solution.
 
 Here is an overview of the steps we will follow:
-1. Create an identity for the HTTP client and assign an attribute "http-clients". We'll use this attribute when authorizing the clients to
-   access the HTTP service
-2. Create an identity for the HTTP server if you are not using an edge-router with the tunneling option enabled (see below). Also note 
-   that if you are using the docker-compose quickstart or just plan to use an edge-router with tunneling enabled you can also skip this 
-   step.
-3. Create an [intercept.v1 config](../../learn/core-concepts/config-store/overview.md). This config is used to instruct the client-side tunneler how 
-   to correctly intercept the targeted traffic and put it onto the overlay.
-4. Create a [host.v1 config](../../learn/core-concepts/config-store/overview.md). This config is used instruct the server-side tunneler how to offload the 
-   traffic from the overlay, back to the underlay.
-5. Create a service to associate the two configs created previously into a service.
-6. Create a service-policy to authorize "HTTP Clients" to "dial" the service representing the HTTP server.
-7. Create a service-policy to authorize the "HTTP Server" to "bind" the service representing the HTTP server.
-8. Create an edge-router-policy to grant all routers access to all identities
-9. Create a service-edge-router-policy to grant all routers access to all services
-10. Start the server-side tunneler (unless using the docker-compose quickstart) with the HTTP server identity, providing access to the 
-   HTTP server.
-11. Start the client-side tunneler using the HTTP client identity.
-12. Access the HTTP server securely over the OpenZiti zero trust overlay
 
-We can do all these steps using the OpenZiti CLI tool: `ziti`. We can also accomplish this using the OpenZiti Admin Console. We'll 
-demonstrate doing it both ways now.
+1. Create an identity for the HTTP client and assign an attribute `http-clients`. We'll use this attribute when
+   authorizing the clients to access the HTTP service.
+2. Create an identity for the HTTP server if you are not using an edge-router with the tunneling option enabled
+   (see below). Also note that if you are using the docker-compose quickstart or just plan to use an edge-router
+   with tunneling enabled you can also skip this step.
+3. Create an [intercept.v1 config](../../learn/core-concepts/config-store/overview.md). This config is used to
+   instruct the client-side tunneler how to correctly intercept the targeted traffic and put it onto the overlay.
+4. Create a [host.v1 config](../../learn/core-concepts/config-store/overview.md). This config is used to instruct
+   the server-side tunneler how to offload the traffic from the overlay, back to the underlay.
+5. Create a service to associate the two configs created previously into a service.
+6. Create a service-policy to authorize `http-clients` to `dial` the service representing the HTTP server.
+7. Create a service-policy to authorize the HTTP server to `bind` the service representing the HTTP server.
+8. Create an edge-router-policy to grant all routers access to all identities.
+9. Create a service-edge-router-policy to grant all routers access to all services.
+10. Start the server-side tunneler (unless using the docker-compose quickstart) with the HTTP server identity,
+    providing access to the HTTP server.
+11. Start the client-side tunneler using the HTTP client identity.
+12. Access the HTTP server securely over the OpenZiti zero trust overlay.
+
+We can do all these steps using the OpenZiti CLI tool: `ziti`. We can also accomplish this using the OpenZiti Admin
+Console. We'll demonstrate doing it both ways now.
 
 ### Configure the overlay using the `ziti` CLI
 
-Here you can find the steps necessary to configure your overlay network. You can copy/paste and run them all at once, or you can go 
-slowly and run one command at a time to see how each command works. These commands are all based on a shell similar to bash. If you are 
-not using bash you'll need to adapt these scripts to your shell.
+Here you can find the steps necessary to configure your overlay network. You can copy/paste and run them all at
+once, or you can go slowly and run one command at a time to see how each command works. These commands are all
+based on a shell similar to bash. If you are not using bash you'll need to adapt these scripts to your shell.
 
 #### HTTP server IP/DNS
-Note that step 4 below requires you to have set the variable named `http_server`. This variable represents the location of the HTTP 
-server relative to the OpenZiti tunneler you're using. Look at the diagram above. You will want to supply the IP/FQDN of the server 
-which runs the HTTP server that is relative to the tunneler. As an example, if you were to use the docker-compose quickstart and are 
-going to reference the pre-deployed HTTP server that comes with it, you'd set `http_server` to `web-test-blue` since that is a valid 
-name of the container running the HTTP server.
+
+Note that step 4 below requires you to have set the variable named `http_server`. This variable represents the
+location of the HTTP server relative to the OpenZiti tunneler you're using. Look at the diagram above. You will
+want to supply the IP/FQDN of the server which runs the HTTP server that is relative to the tunneler. As an
+example, if you were to use the docker-compose quickstart and are going to reference the pre-deployed HTTP server
+that comes with it, you'd set `http_server` to `web-test-blue` since that is a valid name of the container running
+the HTTP server.
 
 #### HTTP server identity
-Note that step 7 below requires you to have set the variable named `http_server_id`. All of the quickstarts provision an edge-router 
-with the tunneler option (`-t`) enabled. This means that edge-router is configured to serve as a tunneler. Run `ziti edge list 
-identities` to find the name of the identity associated to the router.
 
-```textell
+Note that step 7 below requires you to have set the variable named `http_server_id`. All of the quickstarts
+provision an edge-router with the tunneler option (`-t`) enabled. This means that edge-router is configured to
+serve as a tunneler. Run `ziti edge list identities` to find the name of the identity associated to the router.
+
+```text
 # login to your controller - replace the host/port with the correct value
 ziti edge login localhost:1280
 
@@ -255,5 +278,5 @@ Optionally, you may [install the ZAC](../zac/index.mdx) to manage your network w
 
 ### Test everything works
 
-Once you have set everything up As shown in the last step above - at this point you should be able to run a curl
-statement or use a browser to access "http.ziti".
+Once you have set everything up as shown in the last step above, you should be able to run a curl statement or use
+a browser to access `http.ziti`.

--- a/docusaurus/docs/get-started/zac/index.mdx
+++ b/docusaurus/docs/get-started/zac/index.mdx
@@ -11,15 +11,16 @@ explore a [network](@openziti2x/intro).
 
 ## Overview
 
- These steps enable the console for a quickstart controller. Run these commands with a shell like `bash` in a Windows Subsystem for Linux (WSL), macOS, or Linux.
+These steps enable the console for a quickstart controller. Run these commands with a shell like `bash` in a
+Windows Subsystem for Linux (WSL), macOS, or Linux.
 
 ## Download from GitHub
 
-With ZAC 3.0+, the ZAC has been transformed to a single-page-application (SPA) allowing you to download an artifact 
-from GitHub and host the ZAC however you like. The controller was also modified to allow the ZAC to be hosted by the 
-controller. These steps are applicable to both the [Local - No Docker](../network/local-no-docker.mdx) 
-and the [hosted yourself](../network/hosted.mdx) deployments. When complete, the controller will host
-the ZAC on the management API web binding.
+With ZAC 3.0+, the ZAC has been transformed to a single-page-application (SPA) allowing you to download an
+artifact from GitHub and host the ZAC however you like. The controller was also modified to allow the ZAC to be
+hosted by the controller. These steps are applicable to both the [Local — no Docker](../network/local-no-docker.mdx)
+and the [hosted yourself](../network/hosted.mdx) deployments. When complete, the controller will host the
+ZAC on the management API web binding.
 
 1. On the controller host, download any console version >= 3.0.0 from GitHub.
 
@@ -27,7 +28,8 @@ the ZAC on the management API web binding.
     wget https://github.com/openziti/ziti-console/releases/latest/download/ziti-console.zip
     ```
 
-1. Ensure `ZITI_HOME` is set to your quickstart working directory and exported to forked processes. You can always restore the quickstart environment variables by sourcing the environment file.
+1. Ensure `ZITI_HOME` is set to your quickstart working directory and exported to forked processes. You can always
+   restore the quickstart environment variables by sourcing the environment file.
 
    ```text
    source ${HOME}/.ziti/quickstart/$(hostname)/$(hostname).env
@@ -40,7 +42,7 @@ the ZAC on the management API web binding.
     unzip -d ${ZITI_HOME}/console ./ziti-console.zip
     ```
 
-1. In **$&lbrace;ZITI_HOME}/$(hostname -s).yaml**, add a web API binding `zac` in the list containing `edge-management`.
+1. In `${ZITI_HOME}/$(hostname -s).yaml`, add a web API binding `zac` in the list containing `edge-management`.
 
     ```text
           - binding: zac
@@ -55,20 +57,20 @@ the ZAC on the management API web binding.
     sudo systemctl restart ziti-controller.service
     ```
 
-1. Navigate to the console in your web browser using whatever port the management API is configured for. Depending 
-   on which quickstart you have used, the port may be different. The "Local" quickstart defaults to port 1280 while 
-   the "Host OpenZiti Anywhere" quickstart defaults to 8441 and is customizable by you. Make sure you are using the 
-   advertised host and port for your managment API, e.g., `https://ctrl.ziti.example.com:1280/zac/`
+1. Navigate to the console in your web browser using whatever port the management API is configured for. Depending
+   on which quickstart you have used, the port may be different. The "Local" quickstart defaults to port 1280
+   while the "Host OpenZiti Anywhere" quickstart defaults to 8441 and is customizable by you. Make sure you are
+   using the advertised host and port for your management API, e.g., `https://ctrl.ziti.example.com:1280/zac/`.
 
 ## Use Docker
 
 ### Copy PKI from controller
 
-It's a good idea to use TLS everywhere. To do this, you'll need to provide ZAC a key and a certificate.
-If you have used the [Local - With Docker](../network/local-with-docker.mdx) quickstart to start
-the network you can copy the certificates generated when the controller started.
-Shown is an example which copies the certs from the OpenZiti container and uses them with ZAC. We'll copy the files
-from the docker named volume `myPersistentZitiFiles` and put them into a folder at `$HOME/.ziti/zac-pki`.
+It's a good idea to use TLS everywhere. To do this, you'll need to provide ZAC a key and a certificate. If you have
+used the [Local — with Docker](../network/local-with-docker.mdx) quickstart to start the network you can copy the
+certificates generated when the controller started. Shown is an example which copies the certs from the OpenZiti
+container and uses them with ZAC. We'll copy the files from the Docker named volume `myPersistentZitiFiles` and
+put them into a folder at `$HOME/.ziti/zac-pki`.
 
 ```text
 mkdir -p $HOME/.ziti/zac-pki
@@ -87,37 +89,38 @@ docker run -it --rm --name temp \
 ### Start ZAC
 
 With the certificates copied, you will be able to start the ZAC using one Docker command. Also notice the command
-will expose the ZAC http and https ports to your local computer so that you can access the ZAC from outside of Docker.
-If you customized any of these paths, you'll need to replace the paths specified accordingly (the '-v' lines).
+will expose the ZAC http and https ports to your local computer so that you can access the ZAC from outside of
+Docker. If you customized any of these paths, you'll need to replace the paths specified accordingly (the `-v`
+lines).
 
- ```text
- docker run --rm \
-        --name zac \
-        -p 1408:1408 \
-        -p 8443:8443 \
-        -v "$HOME/.ziti/zac-pki/ziti-edge-controller-server.key":/usr/src/app/server.key \
-        -v "$HOME/.ziti/zac-pki/ziti-edge-controller-server.chain.pem":/usr/src/app/server.chain.pem \
-        openziti/zac
- ```
+```text
+docker run --rm \
+       --name zac \
+       -p 1408:1408 \
+       -p 8443:8443 \
+       -v "$HOME/.ziti/zac-pki/ziti-edge-controller-server.key":/usr/src/app/server.key \
+       -v "$HOME/.ziti/zac-pki/ziti-edge-controller-server.chain.pem":/usr/src/app/server.chain.pem \
+       openziti/zac
+```
 
 :::note
-Do note that if you are exposing ports as shown above, you will need to ensure that `ziti-edge-controller` is
-addressable by your machine in order to use Docker in this way. This guide does not go into how to do this in depth.
-One easy, and common mechanism to do this would be to edit the 'hosts' file of your operating system. A quick
-internet search should show you how to accomplish this.
+If you're exposing ports as shown above, you will need to ensure that `ziti-edge-controller` is addressable by
+your machine in order to use Docker in this way. This guide does not go into how to do this in depth. One easy,
+and common mechanism to do this would be to edit the `hosts` file of your operating system. A quick internet
+search should show you how to accomplish this.
 :::
 
 ## Docker Compose
 
-If you have followed the [Local - Docker Compose](../network/local-docker-compose.mdx) quickstart you will have the ZAC
-running already. It's now included with both the default docker-compose file and the simplified-docker-compose file.
-Both compose files will start and expose the ZAC ports on 1408/8443.
+If you have followed the [Local — Docker Compose](../network/local-docker-compose.mdx) quickstart you will have
+the ZAC running already. It's now included with both the default `docker-compose.yml` file and the
+`simplified-docker-compose.yml` file. Both compose files will start and expose the ZAC ports on 1408/8443.
 
 :::note
-Do note that if you are exposing ports as shown above, you will need to ensure that `ziti-edge-controller` is
-addressable by your machine in order to use Docker in this way. This guide does not go into how to do this in depth.
-One easy, and common mechanism to do this would be to edit the 'hosts' file of your operating system. A quick
-internet search should show you how to accomplish this.
+If you're exposing ports as shown above, you will need to ensure that `ziti-edge-controller` is addressable by
+your machine in order to use Docker in this way. This guide does not go into how to do this in depth. One easy,
+and common mechanism to do this would be to edit the `hosts` file of your operating system. A quick internet
+search should show you how to accomplish this.
 :::
 
 ## Kubernetes
@@ -126,15 +129,15 @@ internet search should show you how to accomplish this.
 
 ## Sign in and use ZAC
 
-1. At this point you should be able to navigate to: `https://${ZITI_CTRL_EDGE_ADVERTISED_ADDRESS}:8443`and see the ZAC login
-   screen. (The TLS warnings your browser will show you are normal - it's because these steps use a self-signed certificate
-   generated during the installation process)
+1. At this point you should be able to navigate to `https://${ZITI_CTRL_EDGE_ADVERTISED_ADDRESS}:8443` and see the
+   ZAC login screen. The TLS warnings your browser will show you are normal, because these steps use a self-signed
+   certificate generated during the installation process.
 
    :::note
-   If you are using docker-compose to start your network, when you access ZAC for the first time you will need to
-   specify the url of the controller. Since everything is running **in** docker compose this url is relative to the
-   internal docker compose network that is declared in the compose file. You would enter
-   `https://ziti-edge-controller:1280` as the controller's URL
+   If you're using docker-compose to start your network, when you access ZAC for the first time you will need to
+   specify the url of the controller. Since everything is running *in* Docker Compose this url is relative to the
+   internal Docker Compose network that is declared in the compose file. You would enter
+   `https://ziti-edge-controller:1280` as the controller's URL.
    :::
 
 2. Set the controller as shown (use the correct URL):


### PR DESCRIPTION
## Summary
- Style-guide pass over the last get-started/network page (hosted.mdx)
- Style-guide pass over the get-started/other section (index, services, zac)
- Style-guide pass over the first top-level/shared partial (_cli-change-password.md)

Part of the chunked style-guide rollout tracked in `open-ziti-style-edits.md` (PR #2, following #1342).